### PR TITLE
Fix filter panel mobile

### DIFF
--- a/components/CheckboxGroup.js
+++ b/components/CheckboxGroup.js
@@ -60,6 +60,10 @@ const Fieldset = styled.fieldset`
     }
   }
 
+  label {
+    margin-left: 0.5rem;
+  }
+
   legend {
     cursor: pointer;
     padding: 0 0.5rem;

--- a/components/FilterPanel.js
+++ b/components/FilterPanel.js
@@ -47,7 +47,7 @@ class FilterPanel extends React.Component {
 export default FilterPanel;
 
 const StyledAside = styled.aside`
-  width: calc(100% - 50px);
+  width: 300px;
   background-color: ${props => props.theme.colors.primaryBlue};
   color: ${props => props.theme.colors.white};
   transition: width 0.5s;
@@ -107,7 +107,6 @@ const StyledAside = styled.aside`
   }
 
   @media screen and (min-width: ${props => props.theme.medium}) {
-    width: 25%;
     box-shadow: -2px 0 3px rgba(65, 65, 65, 0.5);
     min-height: calc(100vh - 100px);
     position: relative;

--- a/pages/data.js
+++ b/pages/data.js
@@ -180,6 +180,7 @@ const Wrapper = styled.div`
   position: relative;
   display: flex;
   flex-flow: row wrap;
+  width: 100%;
 `;
 
 const Main = styled.main`
@@ -191,7 +192,8 @@ const Main = styled.main`
   @media screen and (min-width: ${props => props.theme.medium}) {
     position: relative;
     padding: 2em 4rem;
-    width: 75%;
+    width: calc(100% - 300px);
+    flex-grow: 1;
   }
   .filtered-incidents {
     margin: 4rem 0;


### PR DESCRIPTION
Updates filter panel to have a fixed width of 300px and ensures parent container doesn't allow content to overflow device width on small devices. Also adds a small margin on filter panel labels for better readability.

Closes #37 