### PR TITLE
Allow data to specify filter types

### DIFF
--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -43,8 +43,8 @@ class FilterPanel extends React.Component {
           <p>Use the options below to narrow down the data and view more specific trends.</p>
           <form name="filter-panel__checkbox-groups">
             {Object.keys(filterConfigs).map(filterConfig => {
-              const type = filterConfigs[filterConfig].type
-              const name = filterConfigs[filterConfig].name
+              const type = filterConfigs[filterConfig].type;
+              const name = filterConfigs[filterConfig].name;
 
               switch(type) {
                 default:

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -29,7 +29,7 @@ class FilterPanel extends React.Component {
   }
 
   render() {
-    const { chartConfigs, allUniqueRecords, handler, isChecked, dataLoaded } = this.props;
+    const { filterConfigs, allUniqueRecords, handler, isChecked, dataLoaded } = this.props;
 
     if (dataLoaded) {
       return (
@@ -42,15 +42,25 @@ class FilterPanel extends React.Component {
           </header>
           <p>Use the options below to narrow down the data and view more specific trends.</p>
           <form name="filter-panel__checkbox-groups">
-            {Object.keys(chartConfigs).map(chartConfig => (
-              <CheckboxGroup
-                key={chartConfigs[chartConfig].group_by}
-                name={chartConfigs[chartConfig].group_by}
-                values={allUniqueRecords[chartConfigs[chartConfig].group_by]}
-                handler={handler}
-                isChecked={isChecked}
-              />
-            ))}
+            {Object.keys(filterConfigs).map(filterConfig => {
+              const type = filterConfigs[filterConfig].type
+              const name = filterConfigs[filterConfig].name
+
+              switch(type) {
+                case 'checkbox-group':
+                  return(
+                    <CheckboxGroup
+                      key={name}
+                      name={name}
+                      values={allUniqueRecords[name]}
+                      handler={handler}
+                      isChecked={isChecked}
+                    />
+                  );
+                default:
+                  console.warn('Filter configs contained unexpected filter type.');
+              }
+            })}
           </form>
         </StyledAside>
       );

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -47,7 +47,7 @@ class FilterPanel extends React.Component {
               const name = filterConfigs[filterConfig].name
 
               switch(type) {
-                case 'checkbox-group':
+                default:
                   return(
                     <CheckboxGroup
                       key={name}
@@ -57,8 +57,6 @@ class FilterPanel extends React.Component {
                       isChecked={isChecked}
                     />
                   );
-                default:
-                  console.warn('Filter configs contained unexpected filter type.');
               }
             })}
           </form>

--- a/data/datasets_test.js
+++ b/data/datasets_test.js
@@ -14,9 +14,9 @@ export default {
       { type: 'doughnut', group_by: 'sex' },
     ],
     filter_configs: [
-      { name: 'year' },
-      { name: 'race' },
-      { name: 'sex' },
+      { type: 'checkbox-group', name: 'year' },
+      { type: 'checkbox-group', name: 'race' },
+      { type: 'checkbox-group', name: 'sex' },
     ],
   },
   civiliansShot: {
@@ -34,9 +34,9 @@ export default {
       { type: 'doughnut', group_by: 'sex' },
     ],
     filter_configs: [
-      { name: 'year' },
-      { name: 'race' },
-      { name: 'sex' },
+      { type: 'checkbox-group', name: 'year' },
+      { type: 'checkbox-group', name: 'race' },
+      { type: 'checkbox-group', name: 'sex' },
     ],
   },
   officersShot: {
@@ -54,9 +54,9 @@ export default {
       { type: 'doughnut', group_by: 'sex' },
     ],
     filter_configs: [
-      { name: 'year' },
-      { name: 'race' },
-      { name: 'sex' },
+      { type: 'checkbox-group', name: 'year' },
+      { type: 'checkbox-group', name: 'race' },
+      { type: 'checkbox-group', name: 'sex' },
     ],
   },
 };

--- a/data/datasets_test.js
+++ b/data/datasets_test.js
@@ -14,9 +14,9 @@ export default {
       { type: 'doughnut', group_by: 'sex' },
     ],
     filter_configs: [
-      { type: 'checkbox-group', name: 'year' },
-      { type: 'checkbox-group', name: 'race' },
-      { type: 'checkbox-group', name: 'sex' },
+      { name: 'year' },
+      { name: 'race' },
+      { name: 'sex' },
     ],
   },
   civiliansShot: {
@@ -34,9 +34,9 @@ export default {
       { type: 'doughnut', group_by: 'sex' },
     ],
     filter_configs: [
-      { type: 'checkbox-group', name: 'year' },
-      { type: 'checkbox-group', name: 'race' },
-      { type: 'checkbox-group', name: 'sex' },
+      { name: 'year' },
+      { name: 'race' },
+      { name: 'sex' },
     ],
   },
   officersShot: {
@@ -54,9 +54,9 @@ export default {
       { type: 'doughnut', group_by: 'sex' },
     ],
     filter_configs: [
-      { type: 'checkbox-group', name: 'year' },
-      { type: 'checkbox-group', name: 'race' },
-      { type: 'checkbox-group', name: 'sex' },
+      { name: 'year' },
+      { name: 'race' },
+      { name: 'sex' },
     ],
   },
 };

--- a/pages/data.js
+++ b/pages/data.js
@@ -111,6 +111,7 @@ export default class Explore extends React.Component {
     // Render our charts if component is finished loading data
     if (!isLoading && data[activeDataset]) {
       const chartConfigs = datasets[activeDataset].chart_configs;
+      const filterConfigs = datasets[activeDataset].filter_configs;
 
       // Setup our recordKeys
       const recordKeys = Object.keys(data[activeDataset].records);
@@ -163,7 +164,7 @@ export default class Explore extends React.Component {
           </Head>
           <FilterPanel
             dataLoaded
-            chartConfigs={chartConfigs}
+            filterConfigs={filterConfigs}
             handler={this.updateFilters}
             allUniqueRecords={allUniqueRecords}
             isChecked={filters}
@@ -219,7 +220,7 @@ export default class Explore extends React.Component {
         </Head>
         <FilterPanel
           dataLoaded={false}
-          chartConfigs={null}
+          filterConfigs={null}
           handler={this.updateFilters}
           allUniqueRecords={null}
           isChecked={null}


### PR DESCRIPTION
We'd like to add agency and county filters to the "explore the data" page. Since so there are many agencies and counties, it probably doesn't make sense to display those filters as checkbox groups. On the [current "explore the data" page](http://texasjusticeinitiative.org/data/), we show those filters as autocomplete text inputs.

We need to have some way to specify that we'd like to display a filter as something other than a checkbox group. I noticed that the data currently has `filterConfigs` objects, which seems like an appropriate place to specify that (although I don't really know where this data comes from or how difficult it is to change the schema).

This PR allows the data to specify how we'd like to display each filter.

Supports https://github.com/texas-justice-initiative/website-nextjs/issues/3