### PR TITLE
README tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ To start the dev server run:
 
 The url for the dev server will be: http://localhost:3333/
 
+## Javascript Style Guide
+
+To maintain consistency in code formatting and to avoid a ton of problems with Github tracking changes that are just differences in tab width, etc., this repo is set up according to [Wes Bos's No-Sweat™ Eslint and Prettier Setup](https://github.com/wesbos/eslint-config-wesbos)
+
+The [Local/Per Project Install](https://github.com/wesbos/eslint-config-wesbos) is taken care of when you run `yarn` or `npm install`. Please follow the [With VS Code](https://github.com/wesbos/eslint-config-wesbos) instructions (if you're using VS Code) to have the formatting applied on save.
+
 ## Using Next JS
 
 To create a new page, simply create a new js file in [/pages](./pages). You can use this [template](./pages/_template-page.js) as a starter or create your own React Stateless or Class Component.

--- a/README.md
+++ b/README.md
@@ -1,22 +1,14 @@
 # TJI Next JS Website
 
-This is a basic starter. To get started clone this repo and cd to the directory, then run:
+To get started clone this repo and cd to the directory, then run:
 
-`yarn`
+`npm install`
 
 To start the dev server run:
 
-`yarn dev`
-
-Alternatively, you can use npm with `npm install` and `npm run dev` but that's two extra words you have to type and who needs that?
+`npm run dev`
 
 The url for the dev server will be: http://localhost:3333/
-
-## Javascript Style Guide
-
-To maintain consistency in code formatting and to avoid a ton of problems with Github tracking changes that are just differences in tab width, etc., this repo is set up according to [Wes Bos's No-Sweat™ Eslint and Prettier Setup](https://github.com/wesbos/eslint-config-wesbos)
-
-The [Local/Per Project Install](https://github.com/wesbos/eslint-config-wesbos) is taken care of when you run `yarn` or `npm install`. Please follow the [With VS Code](https://github.com/wesbos/eslint-config-wesbos) instructions (if you're using VS Code) to have the formatting applied on save.
 
 ## Using Next JS
 


### PR DESCRIPTION
I'm just getting started with working with the TJI Next JS website, so I figured I'd make some tweaks to the README to reflect some of the things I learned:

- The presence of a `package.lock` and the absence of a `yarn.lock` seems to indicate that we're using npm, so I removed references to Yarn.
- I removed the bit about the JavaScript style guide. I got the Wes Boss linting set up in VSCode, and when I saved a file, it made a ton of changes, which indicated to me that we weren't following that style guide. I'd totally be for setting up linting, whether locally or in CI or both, but for now I thought it made sense to remove that section since it could be confusing for folks just getting started.