### PR TITLE
Fix test datasets

### DIFF
--- a/data/datasets_test.js
+++ b/data/datasets_test.js
@@ -26,7 +26,7 @@ export default {
     description: 'Shootings involving Texas law enforcement since Sept. 2015, as reported to the Office of the Attorney General.',
     icon: 'civilians_shot.svg', // File name for the icon kept in /images/
     urls: {
-      compressed: 'https://api.myjson.com/bins/uwkqf',
+      compressed: 'https://api.myjson.com/bins/1eoput',
       full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/shot_civilians.csv',
     },
     chart_configs: [
@@ -47,7 +47,7 @@ export default {
     description: 'Shootings that injured or killed Texas law enforcement officers since Sept. 2015, as reported to the Office of the Attorney General.',
     icon: 'officers_shot.svg', // File name for the icon kept in /images/
     urls: {
-      compressed: 'https://api.myjson.com/bins/19bhaf',
+      compressed: 'https://api.myjson.com/bins/13dhd1',
       full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/shot_officers.csv',
     },
     chart_configs: [


### PR DESCRIPTION
In https://github.com/texas-justice-initiative/website-nextjs/pull/65, we created a new autocomplete filter component and used it to allow filtering by agencies. I appended some agency names to the test "deaths in custody" dataset in order to test things out, but I forgot to append agency names to the test "civilians shot by officers" and "officers shot by civilian" datasets, which broke those tabs on the "Explore the Data" page.

This PR updates the links to test datasets with `agency_name` data included, fixing those pages.