### PR TITLE
Improve filter panel on Explore the Data page on mobile

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -65,7 +65,7 @@ const StyledFooter = styled.footer`
   padding: 2em;
   hr {
     border-width: 0.4px;
-    width: ${props => props.theme.large};
+    max-width: ${props => props.theme.large};
     margin: 20px auto;
   }
   .footer-section-container {

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -104,12 +104,12 @@ const StyledAside = styled.aside`
   position: absolute;
   top: 0;
   left: 0;
-  bottom: 0;
   z-index: 2;
 
   /* Collapsed panel styles */
   &.closed {
     width: 50px;
+    bottom: 0;
 
     header h4,
     p,

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -79,7 +79,7 @@ class FilterPanel extends React.Component {
       );
     }
     return (
-      <StyledAside className={!this.state.collapsed ? 'open' : 'closed'}>
+      <StyledAside className={!this.state.collapsed ? 'open open--data-not-loaded' : 'closed'}>
         <header>
           <h4>Filter Data</h4>
           <span className="filter-panel__toggle" onClick={this.togglePanel}>
@@ -105,6 +105,11 @@ const StyledAside = styled.aside`
   top: 0;
   left: 0;
   z-index: 2;
+
+  /* Extend panel background to bottom of viewport on mobile until data is loaded */
+  &.open--data-not-loaded {
+    bottom: 0;
+  }
 
   /* Collapsed panel styles */
   &.closed {


### PR DESCRIPTION
I noticed a couple of issues with the filter panel on the "Explore the Data" page on mobile:

- The filters panel was open by default
- The background for the filters panel didn't expand below the first viewport when there was more content

This PR addresses both of those issues.

## Demos

### Mobile

|Before|After|
:-------:|:-----:
![mobile-before](https://user-images.githubusercontent.com/7942714/64481333-2bfc6300-d18f-11e9-8cbc-c8dd4eb6f432.gif) | ![mobile-after](https://user-images.githubusercontent.com/7942714/64481338-42a2ba00-d18f-11e9-9f1a-3a72d2cb32b2.gif)

### Desktop

|Before|After|
:-------:|:-----:
![desktop-before](https://user-images.githubusercontent.com/7942714/64481378-9dd4ac80-d18f-11e9-9f7b-b6e7478e4aad.gif) | ![desktop-after](https://user-images.githubusercontent.com/7942714/64481379-a1683380-d18f-11e9-8342-a9a76cadeea9.gif)

closes https://github.com/texas-justice-initiative/website-nextjs/issues/66