### PR TITLE
Explore the Data download button

### DIFF
--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -7,15 +7,31 @@ class DataDownloadButton extends React.Component {
     this.downloadCsv = this.downloadCsv.bind(this);
   }
 
-  downloadCsv() {
+  csvRows() {
     const { data } = this.props;
     const { records } = data;
     const headers = Object.keys(records);
     const columns = Object.values(records);
     const bodyRows = columns[0].map((cell, rowIndex) => columns.map(column => `"${column[rowIndex]}"`));
-    const rows = [headers].concat(bodyRows);
-    const csvContent = `data:text/csv;charset=utf-8,${rows.map(row => row.join(',')).join('\n')}`;
-    window.open(encodeURI(csvContent));
+
+    return [headers].concat(bodyRows);
+  }
+
+  csvContent() {
+    const csvBody = this.csvRows()
+      .map(row => row.join(','))
+      .join('\n');
+
+    return `data:text/csv;charset=utf-8,${csvBody}`;
+  }
+
+  downloadCsv() {
+    const { fileName } = this.props;
+    const hiddenElement = document.createElement('a');
+    hiddenElement.href = encodeURI(this.csvContent());
+    hiddenElement.target = '_blank';
+    hiddenElement.download = fileName;
+    hiddenElement.click();
   }
 
   render() {
@@ -33,5 +49,6 @@ export default DataDownloadButton;
 
 DataDownloadButton.propTypes = {
   data: PropTypes.object.isRequired,
+  fileName: PropTypes.string.isRequired,
   children: PropTypes.string.isRequired,
 };

--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
 class DataDownloadButton extends React.Component {
   constructor(props) {
@@ -38,9 +39,9 @@ class DataDownloadButton extends React.Component {
     const { children } = this.props;
 
     return (
-      <button className="btn btn--primary btn--chart-toggle" type="button" onClick={this.downloadCsv}>
+      <Button className="btn btn--primary btn--chart-toggle" type="button" onClick={this.downloadCsv}>
         {children}
-      </button>
+      </Button>
     );
   }
 }
@@ -52,3 +53,8 @@ DataDownloadButton.propTypes = {
   fileName: PropTypes.string.isRequired,
   children: PropTypes.string.isRequired,
 };
+
+const Button = styled.button`
+  margin: 0 0 4rem 0;
+  text-transform: none !important;
+`;

--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+class DataDownloadButton extends React.Component {
+  constructor(props) {
+    super(props);
+    this.downloadCsv = this.downloadCsv.bind(this);
+  }
+
+  downloadCsv() {
+    const { data } = this.props;
+    const { records } = data;
+    const headers = Object.keys(records);
+    const columns = Object.values(records);
+    const bodyRows = columns[0].map((cell, rowIndex) => columns.map(column => `"${column[rowIndex]}"`));
+    const rows = [headers].concat(bodyRows);
+    const csvContent = `data:text/csv;charset=utf-8,${rows.map(row => row.join(',')).join('\n')}`;
+    window.open(encodeURI(csvContent));
+  }
+
+  render() {
+    const { children } = this.props;
+
+    return (
+      <button className="btn btn--primary btn--chart-toggle" type="button" onClick={this.downloadCsv}>
+        {children}
+      </button>
+    );
+  }
+}
+
+export default DataDownloadButton;
+
+DataDownloadButton.propTypes = {
+  data: PropTypes.object.isRequired,
+  children: PropTypes.string.isRequired,
+};

--- a/pages/data.js
+++ b/pages/data.js
@@ -227,7 +227,9 @@ export default class Explore extends React.Component {
               ))}
             </ButtonsContainer>
             <div className="filtered-incidents">{datasetHeading}</div>
-            <DataDownloadButton data={filteredData}>Download (csv)</DataDownloadButton>
+            <DataDownloadButton data={filteredData} fileName={`tji_${activeDataset}.csv`}>
+              Download (csv)
+            </DataDownloadButton>
             <ChartContainer>
               {Object.keys(chartConfigs).map(chartConfig => (
                 <div key={chartConfigs[chartConfig].group_by} className="chart">

--- a/pages/data.js
+++ b/pages/data.js
@@ -6,6 +6,7 @@ import fetch from 'isomorphic-unfetch';
 import datasets from '../data/datasets_test';
 import HeroContent from '../components/explore-the-data-page/HeroContent';
 import FilterPanel from '../components/explore-the-data-page/FilterPanel';
+import DataDownloadButton from '../components/explore-the-data-page/DataDownloadButton';
 import BarChart from '../components/charts/chartsjs/BarChart';
 import DoughnutChart from '../components/charts/chartsjs/DoughnutChart';
 
@@ -226,6 +227,7 @@ export default class Explore extends React.Component {
               ))}
             </ButtonsContainer>
             <div className="filtered-incidents">{datasetHeading}</div>
+            <DataDownloadButton data={filteredData}>Download (csv)</DataDownloadButton>
             <ChartContainer>
               {Object.keys(chartConfigs).map(chartConfig => (
                 <div key={chartConfigs[chartConfig].group_by} className="chart">

--- a/pages/data.js
+++ b/pages/data.js
@@ -228,7 +228,7 @@ export default class Explore extends React.Component {
             </ButtonsContainer>
             <div className="filtered-incidents">{datasetHeading}</div>
             <DataDownloadButton data={filteredData} fileName={`tji_${activeDataset}.csv`}>
-              Download (csv)
+              Download (CSV)
             </DataDownloadButton>
             <ChartContainer>
               {Object.keys(chartConfigs).map(chartConfig => (


### PR DESCRIPTION
This PR adds a download CSV button to the "Explore the Data" page that respects the user's choice of dataset and filters. The styles are pretty barebones for now, and I figured we could revisit when we look at the page's design more holistically.

Addresses https://github.com/texas-justice-initiative/website-nextjs/issues/53.

![download-button-demo](https://user-images.githubusercontent.com/7942714/64830898-c42b8b00-d587-11e9-9ae7-7c331c3ab42b.gif)
