### PR TITLE
Display message when filters return no data

### DIFF
--- a/components/charts/chartsjs/BarChart.js
+++ b/components/charts/chartsjs/BarChart.js
@@ -37,6 +37,18 @@ const DeathsByDataType = props => {
   const { recordKeys, records } = props;
   const data = calculateData(recordKeys, records);
 
+  // Do we even have data to chart? If not, just return an empty chart area with some text
+  const recordTotals = data.datasets[0].data;
+  const countData = recordTotals.reduce((acc, curr) => acc + curr);
+
+  if (countData === 0) {
+    return (
+      <div className="bar-chart">
+        <span className="bar-chart__no-data">NO DATA</span>
+      </div>
+    );
+  }
+
   // Sort data descending in order to pull max value
   const sortedData = [...data.datasets[0].data].sort((a, b) => b - a);
   const scaleMax = sortedData[0];

--- a/components/charts/chartsjs/DoughnutChart.js
+++ b/components/charts/chartsjs/DoughnutChart.js
@@ -144,6 +144,18 @@ const DoughnutChart = props => {
   // Setup data and legend for display
   const data = calculateData(recordKeys, records);
 
+  // Do we even have data to chart? If not, just return an empty chart area with some text
+  const recordTotals = data.datasets[0].data;
+  const countData = recordTotals.reduce((acc, curr) => acc + curr);
+
+  if (countData === 0) {
+    return (
+      <div className="doughnut-chart">
+        <span className="doughnut-chart__no-data">NO DATA</span>
+      </div>
+    );
+  }
+
   return (
     <div className="doughnut-chart">
       <Doughnut data={data} options={options} width={300} height={300} />


### PR DESCRIPTION
This updates chart components to return a chart container with text rather than an empty chart when filter combinations result in no data being found.

I've not implemented any styling yet. Will save this to be handled in a separate issue since chart styling hasn't been dealt with yet.

![no-data-tji](https://user-images.githubusercontent.com/22242017/65159772-340f9a80-d9fa-11e9-9fbf-faf3f08daf00.gif)

Fixes #81 