### PR TITLE
Updated Explore the Data page styles

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -78,10 +78,10 @@ const StyledHeader = styled.header`
   padding: 2rem;
   width: 100%;
   z-index: 1;
+  box-shadow: 1px 1px 3px rgba(64, 64, 64, 0.5);
 
   @media (min-width: ${props => props.theme.medium}) {
     position: sticky;
-    box-shadow: 1px 1px 3px rgba(64, 64, 64, 0.5);
     flex-direction: row;
     padding: 2.6rem 5rem 0;
   }

--- a/components/charts/chartsjs/BarChart.js
+++ b/components/charts/chartsjs/BarChart.js
@@ -82,7 +82,7 @@ const DeathsByDataType = props => {
   };
 
   return (
-    <div className="bar-chart">
+    <div className="chart__plot">
       <Bar data={data} options={options} />
     </div>
   );

--- a/components/charts/chartsjs/DoughnutChart.js
+++ b/components/charts/chartsjs/DoughnutChart.js
@@ -157,7 +157,7 @@ const DoughnutChart = props => {
   }
 
   return (
-    <div className="doughnut-chart">
+    <div className="chart__plot">
       <Doughnut data={data} options={options} width={300} height={300} />
       <Legend chartFields={data.labels} />
     </div>

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -32,7 +32,15 @@ class FilterPanel extends React.Component {
   }
 
   render() {
-    const { filterConfigs, allUniqueRecords, handler, isChecked, dataLoaded, handleAutocompleteSelection, updateAll } = this.props;
+    const {
+      filterConfigs,
+      allUniqueRecords,
+      handler,
+      isChecked,
+      dataLoaded,
+      handleAutocompleteSelection,
+      updateAll,
+    } = this.props;
 
     if (dataLoaded) {
       return (
@@ -114,9 +122,10 @@ const StyledAside = styled.aside`
   color: ${props => props.theme.colors.white};
   transition: width 0.5s;
   position: absolute;
-  top: 0;
+  top: 90px;
   left: 0;
   z-index: 2;
+  height: auto;
 
   /* Extend panel background to bottom of viewport on mobile until data is loaded */
   &.open--data-not-loaded {
@@ -125,6 +134,7 @@ const StyledAside = styled.aside`
 
   /* Collapsed panel styles */
   &.closed {
+    height: 100%;
     width: 50px;
     bottom: 0;
 

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -45,11 +45,9 @@ class FilterPanel extends React.Component {
     if (dataLoaded) {
       return (
         <StyledAside className={!this.state.collapsed ? 'open' : 'closed'}>
-          <header>
+          <header onClick={this.togglePanel}>
             <h4>Filter Data</h4>
-            <span className="filter-panel__toggle" onClick={this.togglePanel}>
-              &#8592;
-            </span>
+            <span className="filter-panel__toggle">&#8592;</span>
           </header>
           <p>Use the options below to narrow down the data and view more specific trends.</p>
           <form name="filter-panel__checkbox-groups">
@@ -117,15 +115,16 @@ FilterPanel.propTypes = {
 };
 
 const StyledAside = styled.aside`
-  width: 300px;
   background-color: ${props => props.theme.colors.primaryBlue};
   color: ${props => props.theme.colors.white};
-  transition: width 0.5s;
-  position: absolute;
-  top: 90px;
+  transition: all 0.5s;
+  width: 100%;
+  position: fixed;
+  bottom: 0;
   left: 0;
   z-index: 2;
-  height: auto;
+  height: calc(100vh - 25%);
+  overflow: auto;
 
   /* Extend panel background to bottom of viewport on mobile until data is loaded */
   &.open--data-not-loaded {
@@ -134,35 +133,31 @@ const StyledAside = styled.aside`
 
   /* Collapsed panel styles */
   &.closed {
-    height: 100%;
-    width: 50px;
-    bottom: 0;
+    height: 50px;
 
-    header h4,
     p,
     fieldset {
       display: none;
     }
 
     header {
-      justify-content: center;
-      padding: 2rem 0;
-
       .filter-panel__toggle {
-        transform: rotate(-180deg);
+        transform: rotate(90deg);
       }
     }
   }
-  /* End collapsed styles */
 
   header {
     display: flex;
     flex-flow: row nowrap;
     justify-content: space-between;
+    align-items: center;
     background-color: ${props => props.theme.colors.secondaryBlue};
     padding: 2rem 4rem;
     position: sticky;
     top: 0;
+    height: 50px;
+    cursor: pointer;
 
     h4 {
       color: ${props => props.theme.colors.white};
@@ -173,6 +168,7 @@ const StyledAside = styled.aside`
       display: inline-block;
       cursor: pointer;
       font-size: 2.6rem;
+      transform: rotate(-90deg);
       transition: transform 0.5s;
     }
   }
@@ -183,13 +179,34 @@ const StyledAside = styled.aside`
     line-height: 1.25;
   }
 
+  /* Desktop filter panel */
   @media screen and (min-width: ${props => props.theme.medium}) {
     box-shadow: -2px 0 3px rgba(65, 65, 65, 0.5);
     min-height: calc(100vh - 100px);
     position: relative;
+    width: 300px;
+
+    &.closed {
+      width: 50px;
+      header {
+        justify-content: center;
+        padding: 2rem 0;
+
+        .filter-panel__toggle {
+          transform: rotate(-180deg);
+        }
+
+        h4 {
+          display: none;
+        }
+      }
+    }
 
     header {
       position: relative;
+      .filter-panel__toggle {
+        transform: rotate(0deg);
+      }
     }
   }
 `;

--- a/pages/data.js
+++ b/pages/data.js
@@ -231,7 +231,10 @@ export default class Explore extends React.Component {
             </DataDownloadButton>
             <ChartContainer>
               {Object.keys(chartConfigs).map(chartConfig => (
-                <div key={chartConfigs[chartConfig].group_by} className="chart">
+                <div
+                  key={chartConfigs[chartConfig].group_by}
+                  className={`chart ${chartConfigs[chartConfig].type}-chart`}
+                >
                   <h3 className="chart__group--label">{chartConfigs[chartConfig].group_by.replace(/_/g, ' ')}</h3>
                   {chartConfigs[chartConfig].type === 'bar' ? (
                     <BarChart
@@ -390,25 +393,41 @@ const Main = styled.main`
 `;
 
 const ChartContainer = styled.div`
-  display: flex;
-  flex-flow: row wrap;
-  justify-content: space-evenly;
-  div {
-    margin: 0.5rem;
-    padding: 1.5rem 1rem;
+  display: grid;
+  grid-template-columns: repeat(3, calc(33.33% - 1.33rem));
+  grid-column-gap: 2rem;
+  grid-row-gap: 2rem;
+
+  .chart {
     background: ${props => props.theme.colors.grayLightest};
     border: 1px solid ${props => props.theme.colors.grayLight};
+    padding: 2rem;
   }
-  div.bar-chart {
-    width: 600px;
+
+  .bar-chart,
+  .doughnut-chart {
+    width: 100%;
   }
-  div.doughnut-chart {
-    max-width: 300px;
+
+  .chart__plot {
+    width: 100%;
   }
+
   .chart__group--label {
     text-transform: uppercase;
-    font-size: 1.5rem;
+    font-size: 2rem;
     text-align: center;
+    color: ${props => props.theme.colors.black};
+  }
+
+  @media screen and (min-width: ${props => props.theme.medium}) {
+    .bar-chart {
+      grid-column: 1/3;
+    }
+
+    .doughnut-chart {
+      grid-column: auto;
+    }
   }
 `;
 

--- a/pages/data.js
+++ b/pages/data.js
@@ -407,7 +407,7 @@ const ChartContainer = styled.div`
 
   .bar-chart,
   .doughnut-chart {
-    width: 100%;
+    grid-column: 1/4;
   }
 
   .chart__plot {

--- a/pages/data.js
+++ b/pages/data.js
@@ -211,6 +211,7 @@ export default class Explore extends React.Component {
             <h1>{pageTitle}</h1>
             <HeroContent />
             <ButtonsContainer>
+              <strong>Select a dataset: </strong>
               {datasetNames.map(datasetName => (
                 <ChangeChartButton
                   key={datasetName}
@@ -433,9 +434,11 @@ const ChartContainer = styled.div`
 
 const ButtonsContainer = styled.div`
   display: flex;
+  align-items: center;
 
-  .btn--chart-toggle {
-    margin-right: 1rem;
+  strong,
+  button {
+    margin-right: 2rem;
   }
 `;
 

--- a/pages/data.js
+++ b/pages/data.js
@@ -377,8 +377,8 @@ function filterData(data, filters) {
 const Main = styled.main`
   padding: 1em;
   width: 100%;
-  padding-left: calc(1em + 50px);
   z-index: 1;
+
   @media screen and (min-width: ${props => props.theme.medium}) {
     position: relative;
     padding: 2em 4rem;
@@ -433,12 +433,18 @@ const ChartContainer = styled.div`
 `;
 
 const ButtonsContainer = styled.div`
-  display: flex;
-  align-items: center;
-
-  strong,
   button {
-    margin-right: 2rem;
+    min-width: 250px;
+  }
+  @media screen and (min-width: ${props => props.theme.medium}) {
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+
+    strong,
+    button {
+      margin-right: 2rem;
+    }
   }
 `;
 


### PR DESCRIPTION
There is a lot in this, and more to be done, but I'd like to keep working on this in pieces so there isn't too much tied up in one branch.

1. Updated how charts are displayed for both mobile and desktop

![explore-desktop](https://user-images.githubusercontent.com/22242017/65284886-8b982e00-db00-11e9-98b3-0583e5f299ec.gif)

2. Moved the filter panel to be fixed to the bottom of the window on mobile. It's a big change, but I feel like it gives us more space to display charts and is easier to manage as well.

![explore-mobile](https://user-images.githubusercontent.com/22242017/65284888-8dfa8800-db00-11e9-98e8-b728cfdb93ad.gif)

Future ideas:

1. The top of this page feels really messy and the text is so wide on desktop it is difficult to read. I think we should rework the section of the page above the charts quite a bit. One idea is to pull the step by step instructions out of that block of text and into a tooltip, perhaps which displays when the user hovers over a question mark near the top of the charts?

2. I think the text on the closed state of the filter panel should be more clear on mobile, so that a user knows what to do. Perhaps "Open Filters", and "Close Filters", rather than the arrow.

