### PR TITLE
Fix filter hiding

### DIFF
--- a/components/explore-the-data-page/FilterContainer.js
+++ b/components/explore-the-data-page/FilterContainer.js
@@ -43,16 +43,20 @@ const Fieldset = styled.fieldset`
   padding: 0.35em 0.75em 0.625em;
 
   > div {
+    overflow-x: hidden;
+    overflow-y: hidden;
+    -webkit-transition: max-height 0.5s;
+    -moz-transition: max-height 0.5s;
+    -ms-transition: max-height 0.5s;
+    -o-transition: max-height 0.5s;
+    transition: max-height 0.5s;
+
     &.open {
       max-height: 500px;
-      overflow-x: hidden;
-      overflow-y: hidden;
-      opacity: 1;
     }
 
     &.closed {
       max-height: 0;
-      opacity: 0;
     }
   }
 


### PR DESCRIPTION
Currently, when I hide a filter on the Explore the Data page in Chrome, some weird behavior happens. It seems like even though I no longer see the options for that filter, I can still toggle them by clicking where they used to be.

This PR fixes filter hiding so that when a filter is not visible, it doesn't interfere with the filters below it. It also introduces some snazzy transitions that I stole from the existing site.

## Before this PR

![65285555-ab742580-daf1-11e9-9e84-e52b4dea60f2](https://user-images.githubusercontent.com/7942714/65379670-8a8e0a80-dc80-11e9-926f-62316936218f.gif)

## After this PR

![filter-hide](https://user-images.githubusercontent.com/7942714/65379686-bd380300-dc80-11e9-8abd-1f75f3c00ce9.gif)

Fixes https://github.com/texas-justice-initiative/website-nextjs/issues/91