### PR TITLE
Reintroduce change dataset button icons

### DIFF
--- a/data/datasets.js
+++ b/data/datasets.js
@@ -1,9 +1,13 @@
+const custodialDeathsIcon = require('../images/custodial_deaths.svg');
+const civiliansShotIcon = require('../images/civilians_shot.svg');
+const officersShotIcon = require('../images/officers_shot.svg');
+
 export default {
   custodialDeaths: {
     name: 'deaths in custody',
     chartTitle: 'Deaths in Custody since 2005',
     description: 'All deaths in custody in Texas since 2005, as reported to the Office of the Attorney General.',
-    icon: 'custodial_deaths.svg', // File name for the icon kept in /images/
+    icon: custodialDeathsIcon,
     urls: {
       compressed: 'https://s3.amazonaws.com/tji-compressed-data/cdr_compressed_new.json',
       full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/cleaned_custodial_death_reports.csv',
@@ -36,7 +40,7 @@ export default {
     chartTitle: 'Civilians Shot by Officers since 2015',
     description:
       'Shootings involving Texas law enforcement since Sept. 2015, as reported to the Office of the Attorney General.',
-    icon: 'civilians_shot.svg', // File name for the icon kept in /images/
+    icon: civiliansShotIcon,
     urls: {
       compressed: 'https://s3.amazonaws.com/tji-compressed-data/ois_compressed_new.json',
       full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/shot_civilians.csv',
@@ -63,7 +67,7 @@ export default {
     chartTitle: 'Officers Shot by Civilians since 2015',
     description:
       'Shootings that injured or killed Texas law enforcement officers since Sept. 2015, as reported to the Office of the Attorney General.',
-    icon: 'officers_shot.svg', // File name for the icon kept in /images/
+    icon: officersShotIcon,
     urls: {
       compressed: 'https://s3.amazonaws.com/tji-compressed-data/ois_officers_compressed_new.json',
       full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/shot_officers.csv',

--- a/pages/data.js
+++ b/pages/data.js
@@ -224,6 +224,9 @@ export default class Explore extends React.Component {
                       : 'btn btn--primary btn--chart-toggle'
                   }
                 >
+                  <span className="btn--chart-toggle--icon">
+                    <img src={require('../images/' + datasets[datasetName].icon)} alt={datasets[datasetName].name} />
+                  </span>
                   <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
                 </ChangeChartButton>
               ))}
@@ -285,6 +288,9 @@ export default class Explore extends React.Component {
                     : 'btn btn--primary btn--chart-toggle'
                 }
               >
+                <span className="btn--chart-toggle--icon">
+                  <img src={require('../images/' + datasets[datasetName].icon)} alt={datasets[datasetName].name} />
+                </span>
                 <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
               </ChangeChartButton>
             ))}

--- a/pages/data.js
+++ b/pages/data.js
@@ -225,7 +225,11 @@ export default class Explore extends React.Component {
                   }
                 >
                   <span className="btn--chart-toggle--icon">
-                    <img src={require('../images/' + datasets[datasetName].icon)} alt={datasets[datasetName].name} />
+                    <img
+                      // eslint-disable-next-line import/no-dynamic-require, global-require, prefer-template
+                      src={require('../images/' + datasets[datasetName].icon)}
+                      alt={datasets[datasetName].name}
+                    />
                   </span>
                   <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
                 </ChangeChartButton>
@@ -289,7 +293,11 @@ export default class Explore extends React.Component {
                 }
               >
                 <span className="btn--chart-toggle--icon">
-                  <img src={require('../images/' + datasets[datasetName].icon)} alt={datasets[datasetName].name} />
+                  <img
+                    // eslint-disable-next-line import/no-dynamic-require, global-require, prefer-template
+                    src={require('../images/' + datasets[datasetName].icon)}
+                    alt={datasets[datasetName].name}
+                  />
                 </span>
                 <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
               </ChangeChartButton>

--- a/pages/data.js
+++ b/pages/data.js
@@ -225,11 +225,7 @@ export default class Explore extends React.Component {
                   }
                 >
                   <span className="btn--chart-toggle--icon">
-                    <img
-                      // eslint-disable-next-line import/no-dynamic-require, global-require, prefer-template
-                      src={require('../images/' + datasets[datasetName].icon)}
-                      alt={datasets[datasetName].name}
-                    />
+                    <img src={datasets[datasetName].icon} alt={datasets[datasetName].name} />
                   </span>
                   <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
                 </ChangeChartButton>
@@ -293,11 +289,7 @@ export default class Explore extends React.Component {
                 }
               >
                 <span className="btn--chart-toggle--icon">
-                  <img
-                    // eslint-disable-next-line import/no-dynamic-require, global-require, prefer-template
-                    src={require('../images/' + datasets[datasetName].icon)}
-                    alt={datasets[datasetName].name}
-                  />
+                  <img src={datasets[datasetName].icon} alt={datasets[datasetName].name} />
                 </span>
                 <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
               </ChangeChartButton>

--- a/pages/index.js
+++ b/pages/index.js
@@ -156,6 +156,9 @@ class Index extends React.Component {
                             : 'btn btn--primary btn--chart-toggle'
                         }
                       >
+                        <span className="btn--chart-toggle--icon">
+                          <img src={require('../images/' + datasets[datasetName].icon)} alt={datasets[datasetName].name} />
+                        </span>
                         <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
                       </ChangeChartButton>
                     ))}

--- a/pages/index.js
+++ b/pages/index.js
@@ -157,7 +157,11 @@ class Index extends React.Component {
                         }
                       >
                         <span className="btn--chart-toggle--icon">
-                          <img src={require('../images/' + datasets[datasetName].icon)} alt={datasets[datasetName].name} />
+                          <img
+                            // eslint-disable-next-line import/no-dynamic-require, global-require, prefer-template
+                            src={require('../images/' + datasets[datasetName].icon)}
+                            alt={datasets[datasetName].name}
+                          />
                         </span>
                         <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
                       </ChangeChartButton>

--- a/pages/index.js
+++ b/pages/index.js
@@ -157,11 +157,7 @@ class Index extends React.Component {
                         }
                       >
                         <span className="btn--chart-toggle--icon">
-                          <img
-                            // eslint-disable-next-line import/no-dynamic-require, global-require, prefer-template
-                            src={require('../images/' + datasets[datasetName].icon)}
-                            alt={datasets[datasetName].name}
-                          />
+                          <img src={datasets[datasetName].icon} alt={datasets[datasetName].name} />
                         </span>
                         <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
                       </ChangeChartButton>


### PR DESCRIPTION
This PR reintroduces the change dataset buttons icons that were removed in https://github.com/texas-justice-initiative/website-nextjs/pull/69. I didn't bump into the issue mentioned in https://github.com/texas-justice-initiative/website-nextjs/issues/78, so I'm not sure what has changed since then.

Fixes https://github.com/texas-justice-initiative/website-nextjs/issues/78