### PR TITLE
Fixes for mobile and nav on explore page

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -5,13 +5,19 @@ import Link from 'next/link';
 import styled from 'styled-components';
 
 class Header extends Component {
-  state = { menuHidden: true };
+  constructor(props) {
+    super(props);
+
+    this.state = { menuHidden: true };
+  }
 
   handleMenuToggle = e => {
     // console.log(e.target);
     this.setState(prevState => ({
       menuHidden: !prevState.menuHidden,
     }));
+
+    this.props.onMenuToggle();
   };
 
   render() {

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-unused-vars, global-require, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions, react/destructuring-assignment */
 
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import Link from 'next/link';
 import styled from 'styled-components';
 
@@ -80,6 +81,10 @@ class Header extends Component {
 }
 
 export default Header;
+
+Header.propTypes = {
+  onMenuToggle: PropTypes.func.isRequired,
+};
 
 const StyledHeader = styled.header`
   background-color: ${props => props.theme.colors.white};

--- a/components/Page.js
+++ b/components/Page.js
@@ -13,11 +13,12 @@ class Page extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {headerMenuOpen: false};
+    this.state = { headerMenuOpen: false };
+    this.onHeaderMenuToggle = this.onHeaderMenuToggle.bind(this);
   }
 
   onHeaderMenuToggle() {
-    this.setState({headerMenuOpen: !this.state.headerMenuOpen});
+    this.setState(prevState => ({ headerMenuOpen: !prevState.headerMenuOpen }));
   }
 
   render() {
@@ -26,7 +27,7 @@ class Page extends Component {
         <StyledPage className={this.state.headerMenuOpen ? 'header-menu-open' : ''}>
           <Meta />
           <GlobalStyle />
-          <Header onMenuToggle={this.onHeaderMenuToggle.bind(this)}/>
+          <Header onMenuToggle={this.onHeaderMenuToggle} />
           <InnerContainer>{this.props.children}</InnerContainer>
           <Footer />
         </StyledPage>

--- a/components/Page.js
+++ b/components/Page.js
@@ -10,13 +10,23 @@ import GlobalStyle from '../styles/GlobalStyle';
 import theme from '../theme';
 
 class Page extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {headerMenuOpen: false};
+  }
+
+  onHeaderMenuToggle() {
+    this.setState({headerMenuOpen: !this.state.headerMenuOpen});
+  }
+
   render() {
     return (
       <ThemeProvider theme={theme}>
-        <StyledPage>
+        <StyledPage className={this.state.headerMenuOpen ? 'header-menu-open' : ''}>
           <Meta />
           <GlobalStyle />
-          <Header />
+          <Header onMenuToggle={this.onHeaderMenuToggle.bind(this)}/>
           <InnerContainer>{this.props.children}</InnerContainer>
           <Footer />
         </StyledPage>
@@ -31,7 +41,13 @@ Page.propTypes = {
   children: PropTypes.element.isRequired,
 };
 
-const StyledPage = styled.div``;
+const StyledPage = styled.div`
+  // Stop the page from scrolling when the menu is open on mobile
+  &.header-menu-open {
+    height: 100vh;
+    overflow: hidden;
+  }
+`;
 
 const InnerContainer = styled.div`
   display: flex;

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -125,7 +125,6 @@ const StyledAside = styled.aside`
   bottom: 0;
   left: 0;
   z-index: 2;
-  height: calc(100vh - 25%);
   overflow: auto;
 
   /* Extend panel background to bottom of viewport on mobile until data is loaded */
@@ -135,8 +134,6 @@ const StyledAside = styled.aside`
 
   /* Collapsed panel styles */
   &.closed {
-    height: 50px;
-
     p,
     fieldset {
       display: none;
@@ -179,6 +176,15 @@ const StyledAside = styled.aside`
     margin: 2rem 4rem;
     font-size: ${props => props.theme.sidebarFont__size};
     line-height: 1.25;
+  }
+
+  /** Mobile filter panel */
+  @media screen and (max-width: ${props => props.theme.small}) {
+	height: calc(100vh - 25%);
+
+    &.closed {
+      height: 50px;
+    }
   }
 
   /* Desktop filter panel */

--- a/components/explore-the-data-page/FilterPanel.js
+++ b/components/explore-the-data-page/FilterPanel.js
@@ -180,7 +180,7 @@ const StyledAside = styled.aside`
 
   /** Mobile filter panel */
   @media screen and (max-width: ${props => props.theme.small}) {
-	height: calc(100vh - 25%);
+    height: calc(100vh - 25%);
 
     &.closed {
       height: 50px;


### PR DESCRIPTION
- Make filter panel behave better on mobile
- Allow expanding filter panel by clicking anywhere
- Allow toggling by clicking anyhwere in the panel header
- fix height of open filter panel on mobile
- stop the page from scrolling when menu is open on mobile