### PR TITLE
Fix data download CSV button on Firefox

### DIFF
--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -25,18 +25,16 @@ class DataDownloadButton extends React.Component {
     const { children, fileName } = this.props;
 
     return (
-      <div>
-        <A
-          className="btn btn--primary btn--chart-toggle"
-          ref={this.hiddenLink}
-          href={encodeURI(this.csvContent())}
-          download={fileName}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {children}
-        </A>
-      </div>
+      <A
+        className="btn btn--primary btn--chart-toggle"
+        ref={this.hiddenLink}
+        href={encodeURI(this.csvContent())}
+        download={fileName}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {children}
+      </A>
     );
   }
 }

--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -27,7 +27,6 @@ class DataDownloadButton extends React.Component {
     return (
       <A
         className="btn btn--primary btn--chart-toggle"
-        ref={this.hiddenLink}
         href={encodeURI(this.csvContent())}
         download={fileName}
         target="_blank"

--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -3,12 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 class DataDownloadButton extends React.Component {
-  constructor(props) {
-    super(props);
-    this.downloadCsv = this.downloadCsv.bind(this);
-    this.hiddenLink = React.createRef();
-  }
-
   csvRows() {
     const { data } = this.props;
     const { records } = data;
@@ -27,25 +21,21 @@ class DataDownloadButton extends React.Component {
     return `data:text/csv;charset=utf-8,${csvBody}`;
   }
 
-  downloadCsv() {
-    const { fileName } = this.props;
-    const hiddenLink = this.hiddenLink.current;
-    hiddenLink.href = encodeURI(this.csvContent());
-    hiddenLink.download = fileName;
-    hiddenLink.click();
-  }
-
   render() {
-    const { children } = this.props;
+    const { children, fileName } = this.props;
 
     return (
       <div>
-        <Button className="btn btn--primary btn--chart-toggle" type="button" onClick={this.downloadCsv}>
+        <A
+          className="btn btn--primary btn--chart-toggle"
+          ref={this.hiddenLink}
+          href={encodeURI(this.csvContent())}
+          download={fileName}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           {children}
-        </Button>
-        <a ref={this.hiddenLink} target="_blank" style={{ display: 'none' }}>
-          {children}
-        </a>
+        </A>
       </div>
     );
   }
@@ -59,7 +49,7 @@ DataDownloadButton.propTypes = {
   children: PropTypes.string.isRequired,
 };
 
-const Button = styled.button`
+const A = styled.a`
   margin: 0 0 4rem 0;
   text-transform: none !important;
 `;

--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -6,6 +6,7 @@ class DataDownloadButton extends React.Component {
   constructor(props) {
     super(props);
     this.downloadCsv = this.downloadCsv.bind(this);
+    this.hiddenLink = React.createRef();
   }
 
   csvRows() {
@@ -28,20 +29,24 @@ class DataDownloadButton extends React.Component {
 
   downloadCsv() {
     const { fileName } = this.props;
-    const hiddenElement = document.createElement('a');
-    hiddenElement.href = encodeURI(this.csvContent());
-    hiddenElement.target = '_blank';
-    hiddenElement.download = fileName;
-    hiddenElement.click();
+    const hiddenLink = this.hiddenLink.current;
+    hiddenLink.href = encodeURI(this.csvContent());
+    hiddenLink.download = fileName;
+    hiddenLink.click();
   }
 
   render() {
     const { children } = this.props;
 
     return (
-      <Button className="btn btn--primary btn--chart-toggle" type="button" onClick={this.downloadCsv}>
-        {children}
-      </Button>
+      <div>
+        <Button className="btn btn--primary btn--chart-toggle" type="button" onClick={this.downloadCsv}>
+          {children}
+        </Button>
+        <a ref={this.hiddenLink} target="_blank" style={{ display: 'none' }}>
+          {children}
+        </a>
+      </div>
     );
   }
 }


### PR DESCRIPTION
The download CSV button on the "Explore the Data" page works by creating a hidden link with the CSV data and triggering a click event on it. That was working fine on Chrome and Safari, but we noticed it wasn't working for Firefox. As it turns out, for this tactic to work on Firefox, the hidden link [needs to actually be included somewhere in the DOM](https://stackoverflow.com/a/40676268).

This change updates the download CSV button by adding the hidden link to the DOM so that it will work on Firefox.

closes https://github.com/texas-justice-initiative/website-nextjs/issues/101