### PR TITLE
Remove dynamic requires

### DIFF
--- a/components/BioBox.js
+++ b/components/BioBox.js
@@ -1,5 +1,3 @@
-/* eslint-disable global-require, import/no-dynamic-require */
-
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
@@ -8,7 +6,7 @@ import Parser from './Parser';
 const BioBox = ({ bio }) => (
   <Bio>
     <div id="image">
-      <img src={require(`../images/headshots/${bio.image}`)} alt={bio.name} />
+      <img src={bio.image} alt={bio.name} />
     </div>
     <div id="text">
       <h3>{bio.name}</h3>

--- a/components/Volunteers.js
+++ b/components/Volunteers.js
@@ -1,5 +1,3 @@
-/* eslint-disable global-require, import/no-dynamic-require */
-
 import React from 'react';
 import styled from 'styled-components';
 import volunteers from '../data/volunteers';
@@ -10,11 +8,9 @@ const Volunteers = () => (
       // Documentation about using src and srcset with `next-optimized-images`
       // https://www.npmjs.com/package/next-optimized-images
 
-      const imageSizes = require(`../images/headshots/${vol.image}?resize`);
-
       return (
-        <figure key={vol.image}>
-          <img src={imageSizes.src} srcSet={imageSizes.srcSet} alt={vol.name} />
+        <figure key={vol.name}>
+          <img src={vol.imageSizes.src} srcSet={vol.imageSizes.srcSet} alt={vol.name} />
           <figcaption>
             <h4>{vol.name}</h4>
             <span>{vol.title}</span>

--- a/components/Volunteers.js
+++ b/components/Volunteers.js
@@ -4,20 +4,18 @@ import volunteers from '../data/volunteers';
 
 const Volunteers = () => (
   <Wrapper>
-    {volunteers.map(vol => {
+    {volunteers.map(vol => (
       // Documentation about using src and srcset with `next-optimized-images`
       // https://www.npmjs.com/package/next-optimized-images
 
-      return (
-        <figure key={vol.name}>
-          <img src={vol.imageSizes.src} srcSet={vol.imageSizes.srcSet} alt={vol.name} />
-          <figcaption>
-            <h4>{vol.name}</h4>
-            <span>{vol.title}</span>
-          </figcaption>
-        </figure>
-      );
-    })}
+      <figure key={vol.name}>
+        <img src={vol.imageSizes.src} srcSet={vol.imageSizes.srcSet} alt={vol.name} />
+        <figcaption>
+          <h4>{vol.name}</h4>
+          <span>{vol.title}</span>
+        </figcaption>
+      </figure>
+    ))}
   </Wrapper>
 );
 

--- a/data/bios.js
+++ b/data/bios.js
@@ -1,31 +1,37 @@
+const evaRuthMoravecImage = require('../images/headshots/eva-ruth-moravec.jpg');
+const memeStylesImage = require('../images/headshots/meme-styles.jpg');
+const williamKellyImage = require('../images/headshots/william-kelly.png');
+const karenKennardImage = require('../images/headshots/karen-kennard.png');
+const bryanWhooleryImage = require('../images/headshots/bryan-whoolery.png');
+
 export default {
   evaRuthMoravec: {
     name: 'Eva Ruth Moravec',
-    image: 'eva-ruth-moravec.jpg',
+    image: evaRuthMoravecImage,
     bio:
       '<p>Executive Director and co-founder <a href="https://www.linkedin.com/in/eva-ruth-moravec-m-a-1aa9332/" target="_blank" rel="noopener noreferrer">Eva Ruth Moravec</a> is a 2018<span style="font-weight: 400;"> John Jay/Harry Frank Guggenheim Criminal Justice Reporting fellow, a <a href="https://muckrack.com/profile/portfolio" target="_blank" rel="noopener noreferrer">freelance reporter</a> </span>and the author of a forthcoming book that explores the legality of police shootings in Texas. <span style="font-weight: 400;">While in a data journalism class for her Master’s degree at the University of Texas at Austin, Eva Ruth started a database of officer-involved shootings in Texas. She then explored cases in her database through “<a href="http://pointofimpacttx.com/" target="_blank" rel="noopener noreferrer">Point of Impact</a>,” an investigative journalism series that ran in three Texas daily newspapers. </span><span style="font-weight: 400;">She has covered criminal justice in Texas for a decade, including stints at the </span><i><span style="font-weight: 400;">San Antonio Express-News</span></i><span style="font-weight: 400;"> and The Associated Press. Find her on Twitter <a href="https://twitter.com/EvaRuth?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor" target="_blank" rel="noopener noreferrer">here</a>.</span></p>',
   },
   memeStyles: {
     name: 'Meme Styles',
-    image: 'meme-styles.jpg',
+    image: memeStylesImage,
     bio:
       '<p><a href="https://www.measureaustin.org/meme.html" target="_blank" rel="noopener noreferrer">Meme Styles</a> is the visionary behind MEASURE, a nonprofit she founded in 2015 to build trust, increase transparency and measure progress in underserved communities. As “chief volunteer,” Meme works with the board, leadership team and the community to further the organization’s mission. In 2018, MEASURE successfully advocated in Austin for evidence-based policing as a way to increase collaboration and transparency. Meme, a graduate of American Military University, holds a certificate in Performance Measurement from George Washington University College of Professional Studies. By day, Meme works for the State of Texas as a Privacy Officer, safeguarding data.</p>',
   },
   williamKelly: {
     name: 'William Kelly',
-    image: 'william-kelly.png',
+    image: williamKellyImage,
     bio:
       '<p><a href="http://www.williamkellyphd.com/" target="_blank" rel="noopener noreferrer">William R. Kelly</a> is a Professor of Sociology and Director of the Center for Criminology and Criminal Justice Research at the University of Texas at Austin. A professor and researcher in criminology and criminal justice for over 25 years, he has considerable experience developing, implementing and evaluating a wide variety of criminal justice programs and policies. He has provided expert advice and counsel on big picture justice policy issues as well as the design, implementation, operation and evaluation of very specific justice programs and initiatives, and written four books on reforming the American criminal justice system.</p>',
   },
   karenKennard: {
     name: 'Karen Kennard',
-    image: 'karen-kennard.png',
+    image: karenKennardImage,
     bio:
       '<p><a href="https://www.gtlaw.com/en/professionals/k/kennard-karen-m" target="_blank" rel="noopener noreferrer">Karen M. Kennard</a> is a shareholder at Greenberg Traurig LLP. Karen has practiced law for over 25 years, including 11 as the City Attorney for the City of Austin. There, Karen was instrumental in leading several high-profile initiatives. She started her law career as the Assistant City Attorney for the City of Midland and later worked at the Texas Municipal League, where she provided legal and legislative services to elected and appointed city officials throughout Texas. A graduate of the Texas Tech University School of Law, she is a member of the Austin Chapter of the Links Inc and the Beta Psi Omega Chapter of Alpha Kappa Alpha, Inc.</p>',
   },
   bryanWhoolery: {
     name: 'Bryan Whoolery',
-    image: 'bryan-whoolery.png',
+    image: bryanWhooleryImage,
     bio:
       '<p>Bryan Whoolery is a career police officer with more than 29 years of criminal justice and security-related experience. After spending 28 years at the Travis County Sheriff’s Office, Bryan was selected to become the security director for the Texas Bullion Depository in 2017. As a law enforcement officer, Bryan is an expert at conducting SWAT operations, investigations, juvenile justice, managing critical incidents, executive protection and training. He also teaches as an adjunct instructor for the Travis County Sheriff’s Office and is a member of the Justice Academy’s Research Team for the Hostage Survivability Model.</p>',
   },

--- a/data/volunteers.js
+++ b/data/volunteers.js
@@ -1,77 +1,93 @@
+const jamesBabyakImageSizes = require(`../images/headshots/james-babyak.jpg?resize`);
+const simiDamaniImageSizes = require(`../images/headshots/simi-damani.jpg?resize`);
+const nickHoldenImageSizes = require(`../images/headshots/nick-holden.jpg?resize`);
+const dashielLopezMendezImageSizes = require(`../images/headshots/dashiel-lopez-mendez.jpg?resize`);
+const danielOlivaresImageSizes = require(`../images/headshots/daniel-olivares.jpg?resize`);
+const jonathanPascoeImageSizes = require(`../images/headshots/jonathan-pascoe.jpg?resize`);
+const athulaPudhiyidathImageSizes = require(`../images/headshots/athula-pudhiyidath.jpg?resize`);
+const michaelReedImageSizes = require(`../images/headshots/michael-reed.jpg?resize`);
+const sheaScottImageSizes = require(`../images/headshots/shea-scott.jpg?resize`);
+const jenUdanImageSizes = require(`../images/headshots/jen-udan.jpg?resize`);
+const kaitlynWallaceImageSizes = require(`../images/headshots/kaitlyn-wallace.jpg?resize`);
+const everettWetchlerImageSizes = require(`../images/headshots/everett-wetchler.jpg?resize`);
+const raymondWeyandtImageSizes = require(`../images/headshots/raymond-weyandt.jpg?resize`);
+const aidenYangImageSizes = require(`../images/headshots/aiden-yang.jpg?resize`);
+const jasonZinnImageSizes = require(`../images/headshots/jason-zinn.jpg?resize`);
+
 export default [
   {
     name: 'James Babyak',
     title: 'Data Scientist',
-    image: 'james-babyak.jpg',
+    imageSizes: jamesBabyakImageSizes,
   },
   {
     name: 'Simi Damani',
     title: 'Front-End Developer',
-    image: 'simi-damani.jpg',
+    imageSizes: simiDamaniImageSizes,
   },
   {
     name: 'Nick Holden',
     title: 'Software Engineer',
-    image: 'nick-holden.jpg',
+    imageSizes: nickHoldenImageSizes,
   },
   {
     name: 'Dashiel Lopez Mendez',
     title: 'Infrastructure Engineer',
-    image: 'dashiel-lopez-mendez.jpg',
+    imageSizes: dashielLopezMendezImageSizes,
   },
   {
     name: 'Daniel Olivares',
     title: 'Senior Software Engineer',
-    image: 'daniel-olivares.jpg',
+    imageSizes: danielOlivaresImageSizes,
   },
   {
     name: 'Jonathan Pascoe',
     title: 'Geographic Information Systems Professional',
-    image: 'jonathan-pascoe.jpg',
+    imageSizes: jonathanPascoeImageSizes,
   },
   {
     name: 'Athula Pudhiyidath',
     title: 'Data Scientist',
-    image: 'athula-pudhiyidath.jpg',
+    imageSizes: athulaPudhiyidathImageSizes,
   },
   {
     name: 'Michael Reed',
     title: 'Software Engineer',
-    image: 'michael-reed.jpg',
+    imageSizes: michaelReedImageSizes,
   },
   {
     name: 'Shea Scott',
     title: 'Senior Front-End Developer',
-    image: 'shea-scott.jpg',
+    imageSizes: sheaScottImageSizes,
   },
   {
     name: 'Jen Udan',
     title: 'Front-End Developer',
-    image: 'jen-udan.jpg',
+    imageSizes: jenUdanImageSizes,
   },
   {
     name: 'Kaitlyn Wallace',
     title: 'Data Visualizations Fellow',
-    image: 'kaitlyn-wallace.jpg',
+    imageSizes: kaitlynWallaceImageSizes,
   },
   {
     name: 'Everett Wetchler',
     title: 'Data Scientist',
-    image: 'everett-wetchler.jpg',
+    imageSizes: everettWetchlerImageSizes,
   },
   {
     name: 'Raymond Weyandt',
     title: 'Marketing and Communications Specialist',
-    image: 'raymond-weyandt.jpg',
+    imageSizes: raymondWeyandtImageSizes,
   },
   {
     name: 'Aiden Yang',
     title: 'Data Scientist',
-    image: 'aiden-yang.jpg',
+    imageSizes: aidenYangImageSizes,
   },
   {
     name: 'Jason Zinn',
     title: 'Front-End Developer',
-    image: 'jason-zinn.jpg',
+    imageSizes: jasonZinnImageSizes,
   },
 ];


### PR DESCRIPTION
As part of burning down the number of places we're disabling ESLint rules, this PR makes `require` of headshots more explicit, which allows us to stop disabling the [`import/no-dynamic-require`](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md) and [`global-require`](https://eslint.org/docs/rules/global-require) ESLint rules. 