### PR TITLE
Fix menu toggling logic

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -12,6 +12,12 @@ class Header extends Component {
     this.state = { menuHidden: true };
   }
 
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.state.menuHidden !== prevState.menuHidden) {
+      this.props.onMenuToggle(this.state.menuHidden);
+    }
+  }
+
   handleMenuToggle = e => {
     // console.log(e.target);
     if (window.innerWidth <= parseInt(this.props.theme.medium)) {
@@ -20,12 +26,6 @@ class Header extends Component {
       }));
     }
   };
-
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    if (this.state.menuHidden !== prevState.menuHidden) {
-      this.props.onMenuToggle(this.state.menuHidden);
-    }
-  }
 
   render() {
     return (

--- a/components/Header.js
+++ b/components/Header.js
@@ -14,12 +14,18 @@ class Header extends Component {
 
   handleMenuToggle = e => {
     // console.log(e.target);
-    this.setState(prevState => ({
-      menuHidden: !prevState.menuHidden,
-    }));
-
-    this.props.onMenuToggle();
+    if (window.innerWidth <= parseInt(this.props.theme.medium)) {
+      this.setState(prevState => ({
+        menuHidden: !prevState.menuHidden,
+      }));
+    }
   };
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.state.menuHidden !== prevState.menuHidden) {
+      this.props.onMenuToggle(this.state.menuHidden);
+    }
+  }
 
   render() {
     return (
@@ -84,6 +90,7 @@ export default Header;
 
 Header.propTypes = {
   onMenuToggle: PropTypes.func.isRequired,
+  theme: PropTypes.object.isRequired,
 };
 
 const StyledHeader = styled.header`

--- a/components/Page.js
+++ b/components/Page.js
@@ -17,8 +17,8 @@ class Page extends Component {
     this.onHeaderMenuToggle = this.onHeaderMenuToggle.bind(this);
   }
 
-  onHeaderMenuToggle() {
-    this.setState(prevState => ({ headerMenuOpen: !prevState.headerMenuOpen }));
+  onHeaderMenuToggle(menuHidden) {
+    this.setState(() => ({ headerMenuOpen: !menuHidden }));
   }
 
   render() {
@@ -27,7 +27,7 @@ class Page extends Component {
         <StyledPage className={this.state.headerMenuOpen ? 'header-menu-open' : ''}>
           <Meta />
           <GlobalStyle />
-          <Header onMenuToggle={this.onHeaderMenuToggle} />
+          <Header onMenuToggle={this.onHeaderMenuToggle} theme={theme} />
           <InnerContainer>{this.props.children}</InnerContainer>
           <Footer />
         </StyledPage>


### PR DESCRIPTION
There was a bug in the existing code that caused the menu toggle code to
run whenever any link in the header was clicked.

e.g. when navigating to explore the data one lost the ability to scroll,
because the Page component thought the menu was open and was therefore
using `overflow: hidden`