### PR TITLE
Update sidebar button style

### DIFF
--- a/components/AboutSidebar.js
+++ b/components/AboutSidebar.js
@@ -27,8 +27,8 @@ const AboutSidebar = () => (
 
     <p>We wish to give Texans of all creed more information on how law enforcement agencies and officers operate.</p>
 
-    <h3 style={{ 'margin-bottom': '1em' }}>Join Our Mailing List</h3>
-    <MailchimpForm />
+    <h3 style={{ marginBottom: '1em' }}>Join Our Mailing List</h3>
+    <MailchimpForm buttonClassName="btn btn--secondary" />
   </Sidebar>
 );
 

--- a/components/MailchimpForm.js
+++ b/components/MailchimpForm.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 class MailchimpForm extends Component {
   render() {
-    const { style } = this.props;
+    const { style, buttonClassName } = this.props;
 
     return (
       <form
@@ -15,7 +15,7 @@ class MailchimpForm extends Component {
         <input style={{ marginBottom: '0.5em' }} type="text" placeholder="First name" name="FNAME" required />
         <input style={{ marginBottom: '0.5em' }} type="email" placeholder="Email" name="EMAIL" required />
         <br />
-        <button type="submit" className="btn btn--primary" style={{ marginTop: '0.5em' }}>
+        <button type="submit" className={buttonClassName} style={{ marginTop: '0.5em' }}>
           Subscribe
         </button>
       </form>
@@ -25,6 +25,7 @@ class MailchimpForm extends Component {
 
 MailchimpForm.propTypes = {
   style: PropTypes.object,
+  buttonClassName: PropTypes.string.isRequired,
 };
 
 export default MailchimpForm;

--- a/components/homepage/StateofData.js
+++ b/components/homepage/StateofData.js
@@ -17,7 +17,7 @@ class Callout extends React.Component {
             latest news and legislative action related to officer involved shooting incidents in Texas.{' '}
           </p>
           <FormWrap>
-            <MailchimpForm style={{ 'max-width': '400px' }} />
+            <MailchimpForm style={{ 'max-width': '400px' }} buttonClassName="btn btn--primary" />
           </FormWrap>
         </SignupForm>
       </FlexWrap>

--- a/styles/GlobalStyle.js
+++ b/styles/GlobalStyle.js
@@ -122,6 +122,16 @@ const GlobalStyle = createGlobalStyle`
     }
   }
 
+  .btn--secondary {
+    background-color: ${props => props.theme.colors.secondaryBlue};
+    color: ${props => props.theme.colors.white};
+
+    &:hover {
+      box-shadow: none;
+      background-color: ${props => props.theme.colors.tertiaryBlue};
+    }
+  }
+
   .btn--donate {
     background-color: ${props => props.theme.colors.primaryRed};
     color: ${props => props.theme.colors.white};

--- a/theme.js
+++ b/theme.js
@@ -2,6 +2,7 @@ export default {
   colors: {
     primaryBlue: '#0b5d93',
     secondaryBlue: '#64B8DD',
+    tertiaryBlue: '#7ED2F7',
     primaryRed: '#ce2727',
     secondaryRed: '#F95858',
     primaryYellow: '#FFFD00',


### PR DESCRIPTION
Now that we have a Mailchimp subscribe button in the sidebar, this PR adds a new button style to make that button stand out a bit more on a `primaryBlue` background.

|Current sidebar button|New sidebar button|
|-----------------------|-------------------|
|![old-sidebar-button](https://user-images.githubusercontent.com/7942714/67493449-bbb97c00-f62c-11e9-8410-7382f1fc883a.gif)|![sidebar-button](https://user-images.githubusercontent.com/7942714/67493454-be1bd600-f62c-11e9-981f-7d9fff3b5cc9.gif)|

Very open to suggestions for other colors or styles. LMK what you think!

closes https://github.com/texas-justice-initiative/website-nextjs/issues/136