### PR TITLE
Update Download (CSV) button to use full data

### DIFF
--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -1,33 +1,31 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import Papa from 'papaparse';
 
 class DataDownloadButton extends React.Component {
-  csvRows() {
-    const { data } = this.props;
-    const { records } = data;
-    const headers = Object.keys(records);
-    const columns = Object.values(records);
-    const bodyRows = columns[0].map((cell, rowIndex) => columns.map(column => `"${column[rowIndex]}"`));
-
-    return [headers].concat(bodyRows);
-  }
-
   csvContent() {
-    const csvBody = this.csvRows()
-      .map(row => row.join(','))
-      .join('\n');
-
-    return `data:text/csv;charset=utf-8,${csvBody}`;
+    // https://github.com/mholt/PapaParse/issues/175#issuecomment-75597039
+    const { data } = this.props;
+    const blob = new Blob([Papa.unparse(data)]);
+    return window.URL.createObjectURL(blob, { type: 'text/plain' });
   }
 
   render() {
-    const { fileName } = this.props;
+    const { fileName, data } = this.props;
+
+    if (!data) {
+      return (
+        <Button type="button" className="btn btn--primary btn--chart-toggle" disabled>
+          Download (CSV)
+        </Button>
+      );
+    }
 
     return (
       <A
         className="btn btn--primary btn--chart-toggle"
-        href={encodeURI(this.csvContent())}
+        href={this.csvContent()}
         download={fileName}
         target="_blank"
         rel="noopener noreferrer"
@@ -41,10 +39,14 @@ class DataDownloadButton extends React.Component {
 export default DataDownloadButton;
 
 DataDownloadButton.propTypes = {
-  data: PropTypes.object.isRequired,
+  data: PropTypes.array,
   fileName: PropTypes.string.isRequired,
 };
 
 const A = styled.a`
+  text-transform: none !important;
+`;
+
+const Button = styled.button`
   text-transform: none !important;
 `;

--- a/components/explore-the-data-page/DatasetDetails.js
+++ b/components/explore-the-data-page/DatasetDetails.js
@@ -29,7 +29,7 @@ DatasetDetails.propTypes = {
   datasetDescription: PropTypes.string,
   lastUpdated: PropTypes.string,
   totalIncidents: PropTypes.string.isRequired,
-  data: PropTypes.object.isRequired,
+  data: PropTypes.array,
   fileName: PropTypes.string.isRequired,
 };
 

--- a/pages/data.js
+++ b/pages/data.js
@@ -168,6 +168,15 @@ export default class Explore extends React.Component {
       const filteredData = filterData(data[activeDataset].compressed, filters);
       const totalIncidents = filteredData.records[recordKeys[0]].length;
 
+      // If full data is loaded, filter it using the indicies from the filtered
+      // compressed data so that we can use it in the "Download (CSV)" button.
+      let filteredFullData;
+      if (data[activeDataset].full) {
+        filteredFullData = data[activeDataset].full.filter(
+          (_value, index) => !filteredData.removedRecordIndicies.includes(index)
+        );
+      }
+
       return (
         <React.Fragment>
           <Head>
@@ -208,7 +217,7 @@ export default class Explore extends React.Component {
               datasetDescription={datasets[activeDataset].description}
               totalIncidents={totalIncidents.toLocaleString()}
               lastUpdated={datasets[activeDataset].lastUpdated}
-              data={filteredData}
+              data={filteredFullData}
               fileName={`tji_${activeDataset}.csv`}
             />
             <ChartContainer>
@@ -294,6 +303,7 @@ function filterData(data, filters) {
   // Create an empty object which will become our final data object to be returned
   const filteredData = {
     records: {},
+    removedRecordIndicies: [],
   };
   // Create an empty array which will contain the indices of all records to be filtered
   let filterIndices = [];
@@ -329,10 +339,11 @@ function filterData(data, filters) {
 
   // At this point we have stored the index values of all records to be filtered in the array filterIndices
   // Now we want to remove those records and return a filtered dataset.
+  const uniqueFilters = [...new Set(filterIndices)];
   const cleanedData = {
     records: {},
+    removedRecordIndicies: uniqueFilters,
   };
-  const uniqueFilters = [...new Set(filterIndices)];
 
   // Only process data further if we have any filters to apply, otherwise just return the original object.
   if (uniqueFilters.length > 0) {

--- a/styles/GlobalStyle.js
+++ b/styles/GlobalStyle.js
@@ -117,6 +117,11 @@ const GlobalStyle = createGlobalStyle`
     text-align: center;
     line-height: 1.25;
     font-size: 1.6rem;
+
+    :disabled {
+      opacity: .4;
+      cursor: not-allowed;
+    }
   }
 
   .btn--primary {


### PR DESCRIPTION
On the "Explore the Data" page, we're currently using `compressed` datasets in our graphs and in the CSV downloads. We'd like to continue using the `compressed` datasets in the graphs, but we'd like to use the `full` datasets for the CSV downloads.

This PR updates the page to pass along the filtered `full` data to the download button instead of the filtered `compressed` data. It's built on top of https://github.com/texas-justice-initiative/website-nextjs/pull/180.

supports https://github.com/texas-justice-initiative/website-nextjs/issues/171