### PR TITLE
Add icon to indicate that hover description is available

### DIFF
--- a/pages/data.js
+++ b/pages/data.js
@@ -226,10 +226,13 @@ export default class Explore extends React.Component {
                 {Object.values(chartConfigs).map(chartConfig => (
                   <div key={chartConfig.group_by.name} className={`chart ${chartConfig.type}-chart`}>
                     <div className="chartContainer">
-                      <h3 className="chart__group--label" data-tip={chartConfig.group_by.description}>
-                        <ReactTooltip place="bottom" />
-                        {chartConfig.group_by.name.replace(/_/g, ' ')}
-                      </h3>
+                      <div className="chart__group--label-container" data-tip={chartConfig.group_by.description}>
+                        <h3 className="chart__group--label">
+                          <ReactTooltip place="bottom" />
+                          {chartConfig.group_by.name.replace(/_/g, ' ')}
+                        </h3>
+                        {chartConfig.group_by.description && <span className="chart__group--description-icon">ⓘ</span>}
+                      </div>
                       {chartConfig.type === 'bar' ? (
                         <BarChart
                           recordKeys={allUniqueRecords[chartConfig.group_by.name]}
@@ -413,11 +416,22 @@ const ChartContainer = styled.div`
     height: 90%;
   }
 
-  .chart__group--label {
-    text-transform: uppercase;
-    font-size: 2rem;
-    text-align: center;
-    color: ${props => props.theme.colors.black};
+  .chart__group--label-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    .chart__group--label {
+      text-transform: uppercase;
+      font-size: 2rem;
+      text-align: center;
+      color: ${props => props.theme.colors.black};
+    }
+
+    .chart__group--description-icon {
+      margin-left: 0.6rem;
+      font-size: 80%;
+    }
   }
 
   @media screen and (max-width: ${props => props.theme.medium}) {

--- a/pages/data.js
+++ b/pages/data.js
@@ -420,6 +420,7 @@ const ChartContainer = styled.div`
     display: flex;
     justify-content: center;
     align-items: center;
+    cursor: default;
 
     .chart__group--label {
       text-transform: uppercase;


### PR DESCRIPTION
@haywood added some great tooltips to define some terminology on the "Explore the Data" page. This PR makes them more discoverable by adding a ⓘ icon next to headers of charts with tooltips.

![description-icons](https://user-images.githubusercontent.com/7942714/70965350-3ce92a00-2044-11ea-9360-b332a1cd3a15.gif)

closes https://github.com/texas-justice-initiative/website-nextjs/issues/108