### PR TITLE
Update filter panel

### DIFF
--- a/components/explore-the-data-page/AutocompleteInput.js
+++ b/components/explore-the-data-page/AutocompleteInput.js
@@ -7,17 +7,14 @@ import CheckboxGroup from './CheckboxGroup';
 class AutocompleteInput extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { visibleOptions: [] };
     this.handleInput = this.handleInput.bind(this);
   }
 
   handleInput(event) {
     const { options, handleAutocompleteSelection } = this.props;
     const { value } = event.target;
-    const { visibleOptions } = this.state;
 
-    if (options.includes(value) && !visibleOptions.includes(value)) {
-      this.setState({ visibleOptions: [].concat(visibleOptions, value) });
+    if (options.includes(value)) {
       handleAutocompleteSelection(event);
       event.target.value = '';
     }
@@ -25,7 +22,11 @@ class AutocompleteInput extends React.Component {
 
   render() {
     const { name, options, handler, isChecked, updateAll } = this.props;
-    const { visibleOptions } = this.state;
+
+    const visibleOptions = Object.entries(isChecked[name])
+      .filter(record => record[1] === true)
+      .map(record => record[0]);
+
     return (
       <div>
         <datalist id={`${name}-options`}>

--- a/components/explore-the-data-page/CheckboxGroup.js
+++ b/components/explore-the-data-page/CheckboxGroup.js
@@ -9,6 +9,7 @@ class CheckboxGroup extends React.Component {
     const { name, values, handler, isChecked, valueDecorator, updateAll } = this.props;
     const selectAll = () => updateAll({ groupName: name, isChecked: true });
     const deselectAll = () => updateAll({ groupName: name, isChecked: false });
+
     return (
       <div>
         {values.length ? (

--- a/pages/data.js
+++ b/pages/data.js
@@ -133,7 +133,7 @@ export default class Explore extends React.Component {
     recordKeys.forEach(key => {
       filters[key] = Object.create(null, {});
       const uniqueRecords = [...new Set(newData.records[key])];
-      uniqueRecords.forEach(record => (filters[key][record] = true));
+      uniqueRecords.forEach(record => (filters[key][record] = false));
     });
     this.setState(prevState => ({
       isLoading: false,
@@ -321,25 +321,30 @@ function filterData(records, filters) {
     // This is important to ensure we aren't accidently modifying our object in state
     filteredData.records[filterGroup] = [...records[filterGroup]];
 
-    // Loop through all different value options for each group
-    const groupOptions = Object.keys(filters[filterGroup]);
+    // Are any filters active (true)? If so, let's apply filters for this group, otherwise we want to skip this group completely.
+    const applyFilters = Object.values(filters[filterGroup]).includes(true);
 
-    groupOptions.forEach(groupOption => {
-      if (filters[filterGroup][groupOption] === false) {
-        // Reduce the selected groups records down to those that match our filter, saving the index of those records
-        const matchedRecords = filteredData.records[filterGroup].reduce((acc, curr, index) => {
-          /* record options that are true/false come through here as boolean data types,
-             which was causing a type mismatch between the filter state and the record */
-          const currentOption = typeof curr === 'boolean' ? curr.toString() : curr;
+    if (applyFilters) {
+      // Loop through all different value options for each group
+      const groupOptions = Object.keys(filters[filterGroup]);
 
-          if (currentOption == groupOption) {
-            acc.push(index);
-          }
-          return acc;
-        }, []);
-        filterIndices = filterIndices.concat(matchedRecords);
-      }
-    });
+      groupOptions.forEach(groupOption => {
+        if (filters[filterGroup][groupOption] === false) {
+          // Reduce the selected groups records down to those that match our filter, saving the index of those records
+          const matchedRecords = filteredData.records[filterGroup].reduce((acc, curr, index) => {
+            /* record options that are true/false come through here as boolean data types,
+              which was causing a type mismatch between the filter state and the record */
+            const currentOption = typeof curr === 'boolean' ? curr.toString() : curr;
+
+            if (currentOption == groupOption) {
+              acc.push(index);
+            }
+            return acc;
+          }, []);
+          filterIndices = filterIndices.concat(matchedRecords);
+        }
+      });
+    }
   });
 
   // At this point we have stored the index values of all records to be filtered in the array filterIndices


### PR DESCRIPTION
Contains two updates:

1. Updates filter panel to have an initial state of unchecked. Currently, we have all items checked, which is a bit confusing and makes it difficult to see individual filters.

2. Fixes #177 which addresses an issue with text input filters not resetting nicely on dataset change.