### PR TITLE
Updates to how the map links on the data page work

### DIFF
--- a/components/explore-the-data-page/DatasetDetails.js
+++ b/components/explore-the-data-page/DatasetDetails.js
@@ -1,11 +1,31 @@
-import React from 'react';
-import PropTypes from 'prop-types';
 import Link from 'next/link';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import DataDownloadButton from './DataDownloadButton';
 
+function datasetIdToMapSource(datasetId) {
+  switch (datasetId) {
+    case 'civiliansShot':
+      return 'shot_civilians_source';
+    case 'officersShot':
+      return 'shot_officers_source';
+    default:
+      throw new Error(`Unsupported dataset for map: ${datasetId}`);
+  }
+}
+
+function mapLink(datasetId) {
+  if (datasetId === 'custodialDeaths') return null;
+  return (
+    <Link href={`/map?precheck=${datasetIdToMapSource(datasetId)}`}>
+      <a>View Map</a>
+    </Link>
+  );
+}
+
 export default function DatasetDetails(props) {
-  const { datasetName, datasetDescription, lastUpdated, totalIncidents, data, fileName } = props;
+  const { datasetId, datasetName, datasetDescription, lastUpdated, totalIncidents, data, fileName } = props;
   return (
     <Details>
       <div className="col-left">
@@ -20,15 +40,14 @@ export default function DatasetDetails(props) {
       </div>
       <div className="col-right">
         <DataDownloadButton data={data} fileName={fileName} />
-        <Link href="/map">
-          <a>View Map</a>
-        </Link>
+        {mapLink(datasetId)}
       </div>
     </Details>
   );
 }
 
 DatasetDetails.propTypes = {
+  datasetId: PropTypes.string.isRequired,
   datasetName: PropTypes.string.isRequired,
   datasetDescription: PropTypes.string,
   lastUpdated: PropTypes.string,

--- a/pages/data.js
+++ b/pages/data.js
@@ -1,19 +1,19 @@
 /* eslint-disable guard-for-in, no-restricted-syntax, no-use-before-define, eqeqeq */
 
-import React from 'react';
-import styled from 'styled-components';
-import Head from 'next/head';
 import fetch from 'isomorphic-unfetch';
-import ReactTooltip from 'react-tooltip';
+import Head from 'next/head';
 import Papa from 'papaparse';
-import datasets from '../data/datasets';
-import Layout from '../components/Layout';
-import HeroContent from '../components/explore-the-data-page/HeroContent';
-import FilterPanel from '../components/explore-the-data-page/FilterPanel';
+import React from 'react';
+import ReactTooltip from 'react-tooltip';
+import styled from 'styled-components';
 import BarChart from '../components/charts/chartsjs/BarChart';
-import DoughnutChart from '../components/charts/chartsjs/DoughnutChart';
 import ChartNote from '../components/charts/chartsjs/ChartNote';
+import DoughnutChart from '../components/charts/chartsjs/DoughnutChart';
 import DatasetDetails from '../components/explore-the-data-page/DatasetDetails';
+import FilterPanel from '../components/explore-the-data-page/FilterPanel';
+import HeroContent from '../components/explore-the-data-page/HeroContent';
+import Layout from '../components/Layout';
+import datasets from '../data/datasets';
 import theme from '../theme';
 
 export default class Explore extends React.Component {
@@ -215,6 +215,7 @@ export default class Explore extends React.Component {
                 ))}
               </ButtonsContainer>
               <DatasetDetails
+                datasetId={activeDataset}
                 datasetName={datasets[activeDataset].name}
                 datasetDescription={datasets[activeDataset].description}
                 totalIncidents={totalIncidents.toLocaleString()}

--- a/pages/map.js
+++ b/pages/map.js
@@ -1,11 +1,14 @@
-import React from 'react';
 import Head from 'next/head';
+import PropTypes from 'prop-types';
+import React from 'react';
 import styled from 'styled-components';
 import Layout from '../components/Layout';
 
 class Map extends React.Component {
   render() {
     const pageTitle = 'Maps of TJI Data';
+    const { precheck } = this.props;
+    const url = `https://map-viewer.texasjusticeinitiative.org/?precheck=${precheck}`;
     return (
       <React.Fragment>
         <Head>
@@ -13,13 +16,22 @@ class Map extends React.Component {
         </Head>
         <Layout fullWidth>
           <Main>
-            <MapIframe src="https://map-viewer.texasjusticeinitiative.org/" />
+            <MapIframe src={url} />
           </Main>
         </Layout>
       </React.Fragment>
     );
   }
 }
+
+Map.propTypes = {
+  precheck: PropTypes.string.isRequired,
+};
+
+Map.getInitialProps = async function(context) {
+  const { precheck } = context.query;
+  return { precheck: precheck || '' };
+};
 
 export default Map;
 

--- a/pages/map.js
+++ b/pages/map.js
@@ -6,7 +6,6 @@ import Layout from '../components/Layout';
 
 class Map extends React.Component {
   render() {
-    const pageTitle = 'Maps of TJI Data';
     const { precheck } = this.props;
     const url = `https://map-viewer.texasjusticeinitiative.org/?precheck=${precheck}`;
     return (


### PR DESCRIPTION
- Hide the link for custodial deaths, since we're not happy with that
  map yet

- Pre-select map layers based on the dataset from which the map was
  opened

Fixes https://github.com/texas-justice-initiative/mapping/issues/2