### PR TITLE
Load mission statement immediately on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -203,10 +203,11 @@ class Index extends React.Component {
         <Layout>
           <Primary>
             <FlexWrap>
+              <div className="mission-statement">
+                Texas Justice Initiative is a nonprofit organization that collects, analyzes, publishes oversight for
+                criminal justice data throughout Texas.
+              </div>
               <Banner>
-                <div className="banner-heading">
-                  <h1>Texas Justice Initiative...loading Custodial Deaths data</h1>
-                </div>
                 <div className="banner-wrapper">
                   <div className="banner-left">
                     <div className="bar-chart bar-chart--container">


### PR DESCRIPTION
When a user visits our homepage, the mission statement at the top of the page doesn't load until the data in the graph below has loaded. We don't need to wait for that data to load to show the mission statement, and the current loading message is a little distracting, especially on slower internet connections where the data takes longer to download.

This change ensures that we show the mission statement immediately on initial page load.

### Before screenshot

![homepage-loading-current](https://user-images.githubusercontent.com/7942714/72760185-d00a0800-3b8c-11ea-8f9d-2e9cd64a5bba.gif)

### After screenshot

![homepage-loading-new](https://user-images.githubusercontent.com/7942714/72760189-d4362580-3b8c-11ea-9ccd-e294a36d9c30.gif)
