### PR TITLE
Improve loading state of Explore the Data page

### DIFF
--- a/pages/data.js
+++ b/pages/data.js
@@ -261,38 +261,40 @@ export default class Explore extends React.Component {
         <Head>
           <title>Texas Justice Initiative | {pageTitle}</title>
         </Head>
-        <FilterPanel
-          dataLoaded={false}
-          filterConfigs={null}
-          handler={this.updateFilters}
-          updateAll={this.updateFilterGroup}
-          allUniqueRecords={null}
-          isChecked={null}
-          handleAutocompleteSelection={this.handleAutocompleteSelection}
-        />
-        <Main>
-          <h1>{pageTitle}</h1>
-          <HeroContent />
-          <ButtonsContainer>
-            {datasetNames.map(datasetName => (
-              <ChangeChartButton
-                key={datasetName}
-                onClick={() => this.fetchData(datasetName)}
-                className={
-                  datasetName === activeDataset
-                    ? 'btn btn--primary btn--chart-toggle active'
-                    : 'btn btn--primary btn--chart-toggle'
-                }
-              >
-                <span className="btn--chart-toggle--icon">
-                  <img src={datasets[datasetName].icon} alt={datasets[datasetName].name} />
-                </span>
-                <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
-              </ChangeChartButton>
-            ))}
-          </ButtonsContainer>
-          Loading...
-        </Main>
+        <Layout fullWidth>
+          <FilterPanel
+            dataLoaded={false}
+            filterConfigs={null}
+            handler={this.updateFilters}
+            updateAll={this.updateFilterGroup}
+            allUniqueRecords={null}
+            isChecked={null}
+            handleAutocompleteSelection={this.handleAutocompleteSelection}
+          />
+          <Main>
+            <h1>{pageTitle}</h1>
+            <HeroContent />
+            <ButtonsContainer>
+              {datasetNames.map(datasetName => (
+                <ChangeChartButton
+                  key={datasetName}
+                  onClick={() => this.fetchData(datasetName)}
+                  className={
+                    datasetName === activeDataset
+                      ? 'btn btn--primary btn--chart-toggle active'
+                      : 'btn btn--primary btn--chart-toggle'
+                  }
+                >
+                  <span className="btn--chart-toggle--icon">
+                    <img src={datasets[datasetName].icon} alt={datasets[datasetName].name} />
+                  </span>
+                  <span className="btn--chart-toggle--text">{datasets[datasetName].name}</span>
+                </ChangeChartButton>
+              ))}
+            </ButtonsContainer>
+            Loading...
+          </Main>
+        </Layout>
       </React.Fragment>
     );
   }


### PR DESCRIPTION
When a user visits our Explore the Data page, main content for the page gets pushed to the bottom, below the filter panel, while data loads. As a result, users see a big blank area while they wait for the data to load.

This change fixes the layout to improve the data loading experience.

### Before screenshot

![data-loading-current](https://user-images.githubusercontent.com/7942714/72762688-66422c00-3b95-11ea-9ebe-ca163e8cd8fa.gif)

### After screenshot

![data-loading-new](https://user-images.githubusercontent.com/7942714/72762692-6a6e4980-3b95-11ea-85c1-2dd99369c9b6.gif)
