### PR TITLE
Collapse filters on page load on Explore the Data page

### DIFF
--- a/components/explore-the-data-page/FilterContainer.js
+++ b/components/explore-the-data-page/FilterContainer.js
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 class FilterContainer extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { collapsed: false };
+    this.state = { collapsed: true };
     this.toggleCollapsed = this.toggleCollapsed.bind(this);
   }
 
@@ -65,7 +65,7 @@ const Fieldset = styled.fieldset`
   }
 
   legend {
-    padding: 0 0.5rem;
+    padding: 0 0.25rem;
     font-weight: 800;
     white-space: normal;
 


### PR DESCRIPTION
So that users can see all of the filters when they first load the Explore the Data page, this PR collapses them all by default.

### Before

![before](https://user-images.githubusercontent.com/7942714/73142759-4607e680-4047-11ea-8aa1-882069052d7e.gif)

### After

![after](https://user-images.githubusercontent.com/7942714/73142761-4acc9a80-4047-11ea-97e8-dda6a2942cf3.gif)

closes https://github.com/texas-justice-initiative/website-nextjs/issues/222