### PR TITLE
Pull newsletter content from Netlify CMS markdown

### DIFF
--- a/pages/publications/index.js
+++ b/pages/publications/index.js
@@ -9,7 +9,7 @@ import content from '../../content/publications.md';
 
 const {
   html,
-  attributes: { title },
+  attributes: { title, newslettersHeading, newslettersIntro, newsletters },
 } = content;
 
 const Page = () => (
@@ -23,71 +23,15 @@ const Page = () => (
         <div dangerouslySetInnerHTML={{ __html: html }} />
       </Primary>
       <Sidebar>
-        <h3>State of the Data</h3>
-        <p>
-          In the Texas Justice Initiative’s periodic newsletter, “State of the Data,” we feature our latest data,
-          provide insights and more. Read previous editions:
-        </p>
-        <p>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://mailchi.mp/9b565593c7a4/matching-grant-challenge-help-us-soar-221081"
-          >
-            Issue 1: October 2018
-          </a>
-        </p>
-        <p>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://mailchi.mp/8b29905c144e/state_of_the_data_december_2018"
-          >
-            Issue 2: December 2018
-          </a>
-        </p>
-        <p>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://mailchi.mp/973d370699d1/state_of_the_data_december_2018-316421"
-          >
-            Issue 3: February 2019
-          </a>
-        </p>
-        <p>
-          <a target="_blank" rel="noopener noreferrer" href="https://mailchi.mp/b7f6bf62b4b7/stateofthedata4">
-            Issue 4: April 2019
-          </a>
-        </p>
-        <p>
-          <a target="_blank" rel="noopener noreferrer" href="https://mailchi.mp/01d503312561/stateofthedata4-382825">
-            Issue 5: June 2019
-          </a>
-        </p>
-        <p>
-          <a target="_blank" rel="noopener noreferrer" href="https://mailchi.mp/f085563e4913/stateofthedata4-397117">
-            Issue 6: August 2019
-          </a>
-        </p>
-        <p>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://mailchi.mp/259f91748e16/texas-justice-initiative-state-of-the-data-issue-7"
-          >
-            Issue 7: October 2019
-          </a>
-        </p>
-        <p>
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://mailchi.mp/c10d931588b6/texas-justice-initiative-state-of-the-data-issue-480045"
-          >
-            Issue 8: December 2019
-          </a>
-        </p>
+        <h3>{newslettersHeading}</h3>
+        <p>{newslettersIntro}</p>
+        {newsletters.map((newsletter, k) => (
+          <p key={k}>
+            <a target="_blank" rel="noopener noreferrer" href={newsletter.url}>
+              {newsletter.title}
+            </a>
+          </p>
+        ))}
       </Sidebar>
     </Layout>
   </React.Fragment>


### PR DESCRIPTION
I went straight to master with some [configuration changes](https://github.com/texas-justice-initiative/website-nextjs/blob/68bfa85e239a8f7205f2df998c9bfe84de86fa16/static/admin/config.yml#L35-L42) to add fields to Netlify CMS for the newsletters sidebar on the publications page. I used those new fields in the CMS to [generate Markdown with newsletter content](https://github.com/texas-justice-initiative/website-nextjs/commit/91afbdeedb3fac5876d3fbecfed922e214be9ae9).

This PR updates the publications page to pull newsletter content from markdown. That way, we can add and edit newsletters through the CMS.

supports https://github.com/texas-justice-initiative/website-nextjs/issues/211