### PR TITLE
Consider 2019 data complete for bar charts

### DIFF
--- a/data/datasets.js
+++ b/data/datasets.js
@@ -3,8 +3,7 @@ const civiliansShotIcon = require('../images/civilians_shot.svg');
 const officersShotIcon = require('../images/officers_shot.svg');
 
 const INCOMPLETE_YEAR_NOTE = 'Data from the shaded year is incomplete.';
-const OIS_INCOMPLETE_YEARS = [2015, 2019];
-const CDR_INCOMPLETE_YEARS = [2019, 2020];
+const OIS_INCOMPLETE_YEARS = [2015];
 
 export default {
   custodialDeaths: {
@@ -17,7 +16,7 @@ export default {
       full: 'https://s3.us-east-2.amazonaws.com/tji-public-cleaned-datasets/cleaned_custodial_death_reports.csv',
     },
     chart_configs: [
-      { type: 'bar', group_by: { name: 'year' }, note: INCOMPLETE_YEAR_NOTE, incompleteYears: CDR_INCOMPLETE_YEARS },
+      { type: 'bar', group_by: { name: 'year' }, note: INCOMPLETE_YEAR_NOTE },
       { type: 'doughnut', group_by: { name: 'race' } },
       { type: 'doughnut', group_by: { name: 'sex' } },
       {


### PR DESCRIPTION
We have complete data for 2019, and we [let JavaScript calculate the current year](https://github.com/texas-justice-initiative/website-nextjs/blob/d390c7a505364509b8672edda92b1fc1d57dd60d/components/charts/chartsjs/BarChart.js#L27) to show 2020 data as incomplete. This change ensures that we show 2019 data as complete in our bar charts.

### Homepage demo
![homepage](https://user-images.githubusercontent.com/7942714/74110026-bb8eaf00-4b3d-11ea-9f1b-84094abf43ad.gif)

### Explore the Data page demo
![explore](https://user-images.githubusercontent.com/7942714/74110027-c0536300-4b3d-11ea-8de9-5d46cc40c259.gif)

closes https://github.com/texas-justice-initiative/website-nextjs/issues/239