### PR TITLE
Make "about" sidebar content editable in Netlify CMS

### DIFF
--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -1,3 +1,5 @@
+/* eslint-disable react/no-danger */
+
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';

--- a/components/Sidebar.js
+++ b/components/Sidebar.js
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import MailchimpForm from './MailchimpForm';
+import content from '../content/about-sidebar.md';
+
+const { html } = content;
 
 const Sidebar = props => {
   const { children } = props;
@@ -11,34 +14,7 @@ const Sidebar = props => {
     <StyledAside className="sidebar sidebar--subtle">
       {!haveContent && (
         <React.Fragment>
-          <h3>Our Mission</h3>
-          <p>
-            Collect, vet and publicly release information on criminal justice and policing in Texas while pushing for
-            improved transparency.
-          </p>
-
-          <h3>Our Vision</h3>
-          <p>
-            To give Texans the most dependable data and most complete picture of law enforcement in the state, enabling
-            better understanding.
-          </p>
-
-          <h3>Our Values</h3>
-
-          <p>We provide oversight of the data released by state and local governmental entities.</p>
-
-          <p>
-            We seek to improve understanding through presenting information in a rich context and combining a variety of
-            data.
-          </p>
-
-          <p>
-            We hope to encourage the continuation of Texas’ leadership in transparency in policing and accountability.
-          </p>
-
-          <p>
-            We wish to give Texans of all creed more information on how law enforcement agencies and officers operate.
-          </p>
+          <div dangerouslySetInnerHTML={{ __html: html }} />
         </React.Fragment>
       )}
       {children && children}
@@ -54,7 +30,6 @@ Sidebar.propTypes = {
 
 const StyledAside = styled.aside`
   flex: 1 0 342px /* large breakpoint / 3 */;
-  padding: 1em;
   width: 100%;
 
   @media screen and (min-width: ${props => props.theme.medium}) {

--- a/content/about-sidebar.md
+++ b/content/about-sidebar.md
@@ -1,0 +1,14 @@
+### Our Mission
+Collect, vet and publicly release information on criminal justice and policing in Texas while pushing for improved transparency.
+
+### Our Vision
+To give Texans the most dependable data and most complete picture of law enforcement in the state, enabling better understanding.
+
+### Our Values
+We provide oversight of the data released by state and local governmental entities.
+
+We seek to improve understanding through presenting information in a rich context and combining a variety of data.
+
+We hope to encourage the continuation of Texas’ leadership in transparency in policing and accountability.
+
+We wish to give Texans of all creed more information on how law enforcement agencies and officers operate.

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -106,30 +106,7 @@ class Page extends Component {
               </div>
             </Form>
           </Primary>
-          <Sidebar>
-            <h3>Our Mission</h3>
-            <p>
-              Collect, vet and publicly release information on criminal justice and policing in Texas while pushing for
-              improved transparency.
-            </p>
-            <h3>Our Vision</h3>
-            <p>
-              To give Texans the most dependable data and most complete picture of law enforcement in the state,
-              enabling better understanding.
-            </p>
-            <h3>Our Values</h3>
-            <p>We provide oversight of the data released by state and local governmental entities.</p>
-            <p>
-              We seek to improve understanding through presenting information in a rich context and combining a variety
-              of data.
-            </p>
-            <p>
-              We hope to encourage the continuation of Texas’ leadership in transparency in policing and accountability.
-            </p>
-            <p>
-              We wish to give Texans of all creed more information on how law enforcement agencies and officers operate.
-            </p>
-          </Sidebar>
+          <Sidebar />
         </Layout>
       </React.Fragment>
     );

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -178,36 +178,7 @@ class Page extends React.Component {
             )}
             {formStep === 2 && <ReviewForm formState={formState} total={total} returnToForm={this.returnToForm} />}
           </Primary>
-          <Sidebar>
-            <h3>Our Mission</h3>
-            <p>
-              Collect, vet and publicly release information on criminal justice and policing in Texas while pushing for
-              improved transparency.
-            </p>
-
-            <h3>Our Vision</h3>
-            <p>
-              To give Texans the most dependable data and most complete picture of law enforcement in the state,
-              enabling better understanding.
-            </p>
-
-            <h3>Our Values</h3>
-
-            <p>We provide oversight of the data released by state and local governmental entities.</p>
-
-            <p>
-              We seek to improve understanding through presenting information in a rich context and combining a variety
-              of data.
-            </p>
-
-            <p>
-              We hope to encourage the continuation of Texas’ leadership in transparency in policing and accountability.
-            </p>
-
-            <p>
-              We wish to give Texans of all creed more information on how law enforcement agencies and officers operate.
-            </p>
-          </Sidebar>
+          <Sidebar />
         </Layout>
       </React.Fragment>
     );

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -40,3 +40,11 @@ collections:
           fields:
             - {label: "Title", name: "title", widget: "string"}
             - {label: "URL", name: "url", widget: "string", pattern: ['^https?:\/\/.+\..+', 'Must be a URL']}
+  - name: "components"
+    label: "Components"
+    files:
+    - label: "About sidebar"
+      name: "aboutSidebar"
+      file: "content/about-sidebar.md"
+      fields:
+        - {label: "Body", name: "body", widget: "markdown"}


### PR DESCRIPTION
We show content about our mission, vision, and values in the sidebar on our [about pages](https://texasjusticeinitiative.org/about/) as well as our [contact](https://texasjusticeinitiative.org/contact/) and [donate](https://texasjusticeinitiative.org/donate/) pages. This PR makes that content editable in the Netlify CMS.

supports https://github.com/texas-justice-initiative/website-nextjs/issues/211