### PR TITLE
Make related organizations nav link clickable on explore page

### DIFF
--- a/pages/data.js
+++ b/pages/data.js
@@ -374,7 +374,6 @@ function filterData(records, filters) {
 const Main = styled.main`
   padding: 1em;
   width: 100%;
-  z-index: 1;
 
   @media screen and (min-width: ${props => props.theme.medium}) {
     position: relative;


### PR DESCRIPTION
I noticed that I wasn't able to click the "related organizations" link on the Explore the Data page. It looks like that was because of a `z-index` that I don't think we need. With this change, that link is clickable, and the Explore the Data page still looks good on desktop and mobile.

closes https://github.com/texas-justice-initiative/website-nextjs/issues/247