### PR TITLE
Updated 'About TJI' labels to 'About Us'

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -24,7 +24,7 @@ class Footer extends Component {
           <div className="footer-section footer-section__about-links">
             <h4 className="footer-section-title">About</h4>
             <Link href="/about">
-              <a>About TJI</a>
+              <a>About Us</a>
             </Link>
             <br />
             <Link href="/about-the-data">

--- a/components/Header.js
+++ b/components/Header.js
@@ -59,7 +59,7 @@ class Header extends Component {
                 <ul className="submenu">
                   <li>
                     <Link href="/about">
-                      <a>About TJI</a>
+                      <a>About Us</a>
                     </Link>
                   </li>
                   <li>

--- a/pages/about.js
+++ b/pages/about.js
@@ -11,7 +11,7 @@ import bio from '../data/bios';
 import Volunteers from '../components/Volunteers';
 import DonorThumbnails from '../components/DonorThumbnails';
 
-const pageTitle = 'About TJI';
+const pageTitle = 'About Us';
 
 const About = () => (
   <React.Fragment>


### PR DESCRIPTION
This changes the label for 'About TJI' to 'About Us' in 3 locations - header nav; footer nav; and the about page title.

Closes #230 