### PR TITLE
Fix Cloudinary image uploads via Netlify CMS

### DIFF
--- a/components/BioBox.js
+++ b/components/BioBox.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Image, Transformation } from 'cloudinary-react';
+import CloudinaryImage from './CloudinaryImage';
 import Parser from './Parser';
 import theme from '../theme';
 
@@ -12,9 +12,7 @@ const md = require('markdown-it')({
 const BioBox = ({ bio }) => (
   <Bio>
     <div id="image">
-      <Image publicId={bio.headshot} cloud_name="texas-justice-initiative" secure="true" alt={bio.name}>
-        <Transformation width={theme.fullMediumWidthPixels} crop="scale" />
-      </Image>
+      <CloudinaryImage url={bio.headshot} alt={bio.name} maxWidth={theme.fullMediumWidthPixels} />
     </div>
     <div id="text">
       <h3>{bio.name}</h3>

--- a/components/CloudinaryImage.js
+++ b/components/CloudinaryImage.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Image, Transformation } from 'cloudinary-react';
+import path from 'path';
+
+class CloudinaryImage extends React.Component {
+  render() {
+    const { url, alt, maxWidth, aspectRatio } = this.props;
+
+    return (
+      <Image publicId={path.basename(url)} cloud_name="texas-justice-initiative" secure="true" alt={alt}>
+        <Transformation width={maxWidth} crop="scale" aspect_ratio={aspectRatio} />
+      </Image>
+    );
+  }
+}
+
+CloudinaryImage.propTypes = {
+  url: PropTypes.string.isRequired,
+  alt: PropTypes.string.isRequired,
+  maxWidth: PropTypes.number.isRequired,
+  aspectRatio: PropTypes.number,
+};
+
+export default CloudinaryImage;

--- a/components/DonorThumbnails.js
+++ b/components/DonorThumbnails.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Image, Transformation } from 'cloudinary-react';
+import CloudinaryImage from './CloudinaryImage';
 import content from '../content/about-us.md';
 import theme from '../theme';
 
@@ -16,9 +16,7 @@ const DonorThumbnails = () => (
   <Wrapper>
     {donorLogos.map((donorLogo, key) => (
       <div key={key}>
-        <Image publicId={donorLogo.logo} cloud_name="texas-justice-initiative" secure="true" alt={donorLogo.name}>
-          <Transformation width={theme.halfMediumWidthPixels} crop="scale" />
-        </Image>
+        <CloudinaryImage url={donorLogo.logo} alt={donorLogo.name} maxWidth={theme.halfMediumWidthPixels} />
       </div>
     ))}
   </Wrapper>

--- a/components/Volunteers.js
+++ b/components/Volunteers.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Image, Transformation } from 'cloudinary-react';
+import CloudinaryImage from './CloudinaryImage';
 import content from '../content/about-us.md';
 import theme from '../theme';
 
@@ -19,9 +19,7 @@ const Volunteers = () => (
       // https://www.npmjs.com/package/next-optimized-images
 
       <figure key={vol.name}>
-        <Image publicId={vol.headshot} cloud_name="texas-justice-initiative" secure="true" alt={vol.name}>
-          <Transformation width={theme.halfMediumWidthPixels} crop="scale" aspect_ratio="1" />
-        </Image>
+        <CloudinaryImage url={vol.headshot} alt={vol.name} maxWidth={theme.halfMediumWidthPixels} aspectRatio={1} />
         <figcaption>
           <h4>{vol.name}</h4>
           <span>{vol.title}</span>

--- a/components/homepage/NewsFeed.js
+++ b/components/homepage/NewsFeed.js
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
 import MarkdownIt from 'markdown-it';
-import { Image, Transformation } from 'cloudinary-react';
+import CloudinaryImage from '../CloudinaryImage';
 import newsfeed from '../../content/newsfeed.md';
 import Parser from '../Parser';
 import theme from '../../theme';
@@ -89,14 +89,11 @@ class NewsFeed extends React.Component {
                 <li className="news__item" key={k}>
                   {item.thumbnail && (
                     <div className="news__item__image">
-                      <Image
-                        publicId={item.thumbnail}
-                        cloud_name="texas-justice-initiative"
-                        secure="true"
+                      <CloudinaryImage
+                        url={item.thumbnail}
                         alt={item.title}
-                      >
-                        <Transformation width={theme.newsItemImageWidthPixels} crop="scale" />
-                      </Image>
+                        maxWidth={theme.newsItemImageWidthPixels}
+                      />
                     </div>
                   )}
                   <div className="news__item__content">

--- a/content/about-us.md
+++ b/content/about-us.md
@@ -23,64 +23,83 @@ who:
       Express-News* and The Associated Press. Find her on Twitter <a
       href="https://twitter.com/EvaRuth?ref_src=twsrc%5Egoogle%7Ctwcamp%5Eserp%7Ctwgr%5Eauthor"
       target="_blank" rel="noopener noreferrer">here</a>.
-    headshot: eva-ruth-moravec_iyilfi.jpg
+    headshot: >-
+      https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583373618/eva-ruth-moravec_iyilfi.jpg
   volunteerTeam:
     title: Volunteer Team
     volunteers:
       - name: James Babyak
         title: Data Scientist
-        headshot: james-babyak_cmomxc.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583373811/james-babyak_cmomxc.jpg
       - name: Simi Damani
         title: Front-End Developer
-        headshot: simi-damani_laqyha.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583373850/simi-damani_laqyha.jpg
       - name: Anastasia Efremova
         title: Data Scientist
-        headshot: AnastasiaEfremova_1_f5z7rz.png
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583973637/AnastasiaEfremova_1_f5z7rz.png
       - name: Nick Holden
         title: Software Engineer
-        headshot: nick-holden_h6exr6.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583373897/nick-holden_h6exr6.jpg
       - name: Dashiel Lopez Mendez
         title: Infrastructure Engineer
-        headshot: dashiel-lopez-mendez_ctgk5o.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583373932/dashiel-lopez-mendez_ctgk5o.jpg
       - name: Daniel Olivares
         title: Senior Software Engineer
-        headshot: daniel-olivares_mwwge0.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583373984/daniel-olivares_mwwge0.jpg
       - name: Jonathan Pascoe
         title: Geographic Information Systems Professional
-        headshot: jonathan-pascoe_lcij2b.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374057/jonathan-pascoe_lcij2b.jpg
       - name: Athula Pudhiyidath
         title: Data Scientist
-        headshot: athula-pudhiyidath_u2d1pu.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374106/athula-pudhiyidath_u2d1pu.jpg
       - name: Michael Reed
         title: Software Engineer
-        headshot: michael-reed_whsnoa.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374142/michael-reed_whsnoa.jpg
       - name: Shea Scott
         title: Senior Front-End Developer
-        headshot: shea-scott_y7un1c.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374476/shea-scott_y7un1c.jpg
       - name: Jen Udan
         title: Front-End Developer
-        headshot: jen-udan_auwxyy.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374509/jen-udan_auwxyy.jpg
       - name: Kaitlyn Wallace
         title: Data Visualizations Fellow
-        headshot: kaitlyn-wallace_wimcib.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374547/kaitlyn-wallace_wimcib.jpg
       - name: Everett Wetchler
         title: Data Scientist
-        headshot: everett-wetchler_nwe6hc.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374586/everett-wetchler_nwe6hc.jpg
       - name: Raymond Weyandt
         title: Marketing and Communications Specialist
-        headshot: raymond-weyandt_gxupnz.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374621/raymond-weyandt_gxupnz.jpg
       - name: Aiden Yang
         title: Data Scientist
-        headshot: aiden-yang_ignryi.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374656/aiden-yang_ignryi.jpg
       - name: Jason Zinn
         title: Front-End Developer
-        headshot: jason-zinn_d5mwdd.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374691/jason-zinn_d5mwdd.jpg
       - name: Hongsup Shin
         title: Data Scientist
-        headshot: hongsup-shin_hmegrv.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374725/hongsup-shin_hmegrv.jpg
       - name: Bergan Casey
         title: Data Marketing and Communications Specialist
-        headshot: bergan-casey_gzudmf.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374759/bergan-casey_gzudmf.jpg
   governance:
     title: Governance
     body: >-
@@ -104,7 +123,8 @@ who:
           Measurement from George Washington University College of Professional
           Studies. By day, Meme works for the State of Texas as a Privacy
           Officer, safeguarding data.
-        headshot: meme-styles_zfsh5l.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375216/meme-styles_zfsh5l.jpg
       - name: William Kelly
         biography: >-
           <a href="http://www.williamkellyphd.com/" target="_blank"
@@ -118,7 +138,8 @@ who:
           issues as well as the design, implementation, operation and evaluation
           of very specific justice programs and initiatives, and written four
           books on reforming the American criminal justice system.
-        headshot: william-kelly_jtltdc.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375284/william-kelly_jtltdc.jpg
       - name: Karen Kennard
         biography: >-
           <a href="https://www.gtlaw.com/en/professionals/k/kennard-karen-m"
@@ -133,7 +154,8 @@ who:
           Tech University School of Law, she is a member of the Austin Chapter
           of the Links Inc and the Beta Psi Omega Chapter of Alpha Kappa Alpha,
           Inc.
-        headshot: karen-kennard_em2dw2.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375350/karen-kennard_em2dw2.jpg
       - name: Bryan Whoolery
         biography: >-
           Bryan Whoolery is a career police officer with more than 29 years of
@@ -146,7 +168,8 @@ who:
           adjunct instructor for the Travis County Sheriff’s Office and is a
           member of the Justice Academy’s Research Team for the Hostage
           Survivability Model.
-        headshot: bryan-whoolery_ifvocg.jpg
+        headshot: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375412/bryan-whoolery_ifvocg.jpg
   donors:
     title: Our Donors
     body: >-
@@ -156,13 +179,17 @@ who:
       and Florence Newman Foundation, and the Charles Koch Institute.
     donorLogos:
       - name: Awesome Foundation Austin
-        logo: Awesome-ATX-300x300_cph3ke.png
+        logo: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375661/Awesome-ATX-300x300_cph3ke.png
       - name: Charles Koch Institute
-        logo: CKI-Logo-RGB-300x300_gn4m1h.png
+        logo: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375748/CKI-Logo-RGB-300x300_gn4m1h.png
       - name: Credcon
-        logo: credcon_logo_small_lsh3xy.jpg
+        logo: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375790/credcon_logo_small_lsh3xy.jpg
       - name: John & Florence Newman Foundation
-        logo: Newmanlogo-thumb-360x200_aexkd6.png
+        logo: >-
+          https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583375822/Newmanlogo-thumb-360x200_aexkd6.png
 ---
 After Michael Brown was shot and killed by former officer Darren Wilson in Ferguson, Missouri, in 2014, Americans suddenly realized the dismal state of data-collection on officer-involved shootings.
 

--- a/content/newsfeed.md
+++ b/content/newsfeed.md
@@ -13,7 +13,8 @@ news:
       die in a hospital was physically unable to sign his bond paperwork.
       According to the local coroner, the sheriff's office only reported the
       death as a custodial one after the coroner alerted the Texas Rangers.
-    thumbnail: MRT_amoetr.png
+    thumbnail: >-
+      https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583099398/MRT_amoetr.png
   - date: '2020-01-22'
     description: >-
       For the next nine months, 16 law enforcement officials will meet in
@@ -23,7 +24,8 @@ news:
       Police Officer Health, Reduction of Crime and Respect for Law Enforcement.
     link: >-
       https://www.washingtonpost.com/crime-law/2020/01/22/attorney-general-barr-launches-presidential-commission-law-enforcement/
-    thumbnail: WashPostStacked_New_600x_dzgof0.png
+    thumbnail: >-
+      https://res.cloudinary.com/texas-justice-initiative/image/upload/v1582687679/WashPostStacked_New_600x_dzgof0.png
     title: 'Attorney general launches presidential commission on law enforcement '
   - date: '2020-01-23'
     description: >-
@@ -32,7 +34,8 @@ news:
       inmates with serious medical conditions."
     link: >-
       https://www.texasobserver.org/jail-deaths-in-bexar-county-highlight-callous-care-in-custody/
-    thumbnail: download_mifcbf.svg
+    thumbnail: >-
+      https://res.cloudinary.com/texas-justice-initiative/image/upload/v1582687831/download_mifcbf.svg
     title: Jail Deaths in Bexar County Highlight 'Callous' Care in Custody
   - date: '2020-01-10'
     description: >-
@@ -41,7 +44,7 @@ news:
       deaths last year - a record high."
     link: >-
       https://www.palestineherald.com/news/death-without-conviction-texas-jail-deaths-hit-record-number-in/article_f740ab4e-33ea-11ea-8808-0b080e3512c4.html
-    thumbnail: PHP_p0mrmz.png
+    thumbnail: >-
+      https://res.cloudinary.com/texas-justice-initiative/image/upload/v1582688026/PHP_p0mrmz.png
     title: 'Death without conviction: Texas jail deaths hit record number in 2019'
 ---
-

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -3,7 +3,7 @@ backend:
   # Swap out "git-gateway" with "test-repo" and 
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: "git-gateway"
-  branch: fix-cloudinary-images
+  branch: master
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -3,7 +3,7 @@ backend:
   # Swap out "git-gateway" with "test-repo" and 
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: "git-gateway"
-  branch: master
+  branch: fix-cloudinary-images
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow
@@ -106,7 +106,6 @@ collections:
         - {label: "Body", name: "body", widget: "markdown"}
 media_library:
   name: "cloudinary"
-  output_filename_only: true
   config:
     cloud_name: "texas-justice-initiative"
     api_key: "117183127965674"


### PR DESCRIPTION
We're currently using the `cloudinary-react` library to include images from Cloudinary on the site. That library's `<Image>` component expects a filename as a `publicId` prop. If we pass it a full URL instead, Cloudinary won't perform our desired transformations and we end up downloading unoptimized images.

So that we could pass just filenames to `<Image>`, I had originally set the `output_filename_only: true` configuration for the Cloudinary media library so that Netlify CMS would store filenames instead of full URLs in our markdown. This ended up causing two issues:

- An outstanding bug -- https://github.com/netlify/netlify-cms/issues/1934 -- prevents image previews from working in the CMS with `output_filename_only: true`.
- As we learned this week, `output_filename_only: true` wasn't even outputting filenames! It output non-existent local paths like [this one](https://github.com/texas-justice-initiative/website-nextjs/commit/f87377cad05e12145319ba7e6c203f98133b55bf#diff-536ed17bb9a67c7b64d24199a2b1f4efR83).

Moral of the story: `output_filename_only: true` is bad news. This PR removes that configuration. As a result, we store full Cloudinary URLs in our markdown, and it's our responsibility to grab the filenames from those URLs and pass them along to `<Image>`.

There was already some duplication in the way we inserted Cloudinary images, and this change would introduce more, so I extracted a new `CloudinaryImage` component as a wrapper around the `cloudinary-react` functionality.