### PR TITLE
Change dashboard link to TJI Tableau public acct

### DIFF
--- a/pages/publications/pre-conviction-deaths-in-texas-jails.js
+++ b/pages/publications/pre-conviction-deaths-in-texas-jails.js
@@ -41,7 +41,7 @@ class Page extends Component {
               </a>
               , on a laptop or desktop screen for best results.
             </p>
-            <TableauReport url="https://public.tableau.com/views/TJI-BailReform/Deaths_Bail" />
+            <TableauReport url="https://public.tableau.com/views/TJI-BailReform_15794614539010/Deaths_Bail" />
           </Primary>
         </Layout>
       </React.Fragment>


### PR DESCRIPTION
This is to change the link for the TJI Bail Deaths page to link with the TJI Tableau Public account.
Beforehand, it was linked to my personal Tableau Public account.