### PR TITLE
Use GitHub backend for Netlify CMS to attribute commits to authors

### DIFF
--- a/content/about-us.md
+++ b/content/about-us.md
@@ -40,7 +40,7 @@ who:
         title: Data Scientist
         headshot: >-
           https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583973637/AnastasiaEfremova_1_f5z7rz.png
-      - name: Nick Holden!
+      - name: Nick Holden
         title: Software Engineer
         headshot: >-
           https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583373897/nick-holden_h6exr6.jpg

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,9 +1,10 @@
 backend:
   # If you want to test changes made to your config.yml file locally: 
-  # Swap out "git-gateway" with "test-repo" and 
+  # Swap out "github" with "test-repo" and 
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
-  name: "git-gateway"
-  branch: master
+  name: github
+  repo: texas-justice-initiative/website-nextjs
+  branch: use-github-backend
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: github
   repo: texas-justice-initiative/website-nextjs
-  branch: use-github-backend
+  branch: master
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow


### PR DESCRIPTION
By using a GitHub OAuth app to authenticate users in the Netlify CMS, we can attribute changes to their authors in our commit history. Read more at https://www.netlifycms.org/docs/github-backend.

closes https://github.com/texas-justice-initiative/website-nextjs/issues/266