### PR TITLE
Fix newsfeed dates

### DIFF
--- a/components/homepage/NewsFeed.js
+++ b/components/homepage/NewsFeed.js
@@ -4,6 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import styled from 'styled-components';
 import MarkdownIt from 'markdown-it';
+import moment from 'moment';
 import CloudinaryImage from '../CloudinaryImage';
 import newsfeed from '../../content/newsfeed.md';
 import Parser from '../Parser';
@@ -100,7 +101,7 @@ class NewsFeed extends React.Component {
                     <a href={item.link} className="news__item__read-more" target="_blank" rel="noopener noreferrer">
                       <h3>{item.title}</h3>
                     </a>
-                    {item.date && <div className="news__item__date">Published on {item.date}</div>}
+                    <div className="news__item__date">Published on {moment(item.date).format('MMMM D, YYYY')}</div>
                     {item.description && <Parser>{md.render(item.description)}</Parser>}
                   </div>
                 </li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9258,9 +9258,9 @@
       }
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
+      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "imagemin-svgo": "^7.0.0",
     "isomorphic-unfetch": "^3.0.0",
     "markdown-it": "^9.1.0",
+    "moment": "^2.26.0",
     "next": "^9.3.2",
     "next-compose-plugins": "^2.1.1",
     "next-optimized-images": "^2.4.0",

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -23,7 +23,7 @@ collections:
           widget: "list"
           fields:
             - {label: "Title", name: "title", widget: "string"}
-            - {label: "Publish Date", name: "date", widget: "date", format: "YYYY-MM-DD"}
+            - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD", timeFormat: false, pickerUtc: true}
             - {label: "Featured Image", name: "thumbnail", widget: "image", required: false}
             - {label: "Article Link", name: "link", widget: "string", pattern: ['^https?:\/\/.+\..+', 'Must be a URL']}
             - {label: "Description", name: "description", widget: "markdown"}


### PR DESCRIPTION
This PR fixes issues with the "published on" dates in the items under "What We're Reading" on our homepage.

In the CMS, we're having trouble adding new newsfeed items. I suspected it has to do with the Netlify CMS [`date` widget, which is deprecated](https://www.netlifycms.org/docs/widgets/#date). This change replaces it with the [`datetime` widget](https://www.netlifycms.org/docs/widgets/#datetime).

On our homepage, dates are showing up as ugly ISO 8601 strings (e.g. `2020-04-26T00:00:00.000Z`). This is because Netlify CMS recently made a change that stores our dates as actual date objects instead of strings in our markdown (e.g. `date: 2020-05-21` instead of `date: "2020-05-21"`). [`frontmatter-markdown-loader` parses these as ISO 8601 strings](https://github.com/hmsk/frontmatter-markdown-loader/issues/134). This change [parses and formats those strings with moment.js](https://momentjs.com/docs/#/displaying/format/).

closes https://github.com/texas-justice-initiative/website-nextjs/issues/303