### PR TITLE
Capture video plays in Google Analytics

### DIFF
--- a/components/VideoPlayer.js
+++ b/components/VideoPlayer.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import ReactGA from 'react-ga';
+import 'focus-visible';
+
+class VideoPlayer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.onPlay = this.onPlay.bind(this);
+  }
+
+  onPlay() {
+    const { title } = this.props;
+
+    ReactGA.event({
+      category: 'Videos',
+      action: 'play',
+      label: title,
+    });
+  }
+
+  render() {
+    const { url } = this.props;
+    return <Player controls src={url} width="100%" onPlay={this.onPlay}></Player>;
+  }
+}
+
+export default VideoPlayer;
+
+VideoPlayer.propTypes = {
+  url: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+};
+
+const Player = styled.video`
+  background-color: transparent;
+
+  :focus:not(.focus-visible) {
+    outline: none;
+  }
+`;

--- a/content/about-us.md
+++ b/content/about-us.md
@@ -194,18 +194,6 @@ who:
         title: Data Scientist
         headshot: https://res.cloudinary.com/texas-justice-initiative/image/upload/v1583374656/aiden-yang_ignryi.jpg
 ---
-<div style="position: relative; width: 100%; padding-top: 56.25%; /* 16:9 Aspect Ratio */">
-<iframe
-  src="https://player.cloudinary.com/embed/?cloud_name=texas-justice-initiative&public_id=tji-intro-video-long-updated_i6rybk&fluid=true&controls=true&source_types%5B0%5D=mp4&show_logo=false"
-  width="100%"
-  height="100%"
-  allow="fullscreen; encrypted-media; picture-in-picture"
-  allowfullscreen
-  frameborder="0"
-  style="position: absolute; top: 0; bottom: 0; left: 0; right: 0;"
-></iframe>
-</div>
-
 After Michael Brown was shot and killed by former officer Darren Wilson in Ferguson, Missouri, in 2014, Americans suddenly realized the dismal state of data-collection on officer-involved shootings.
 
 A scramble ensued to track how often members of the <a href="http://www.politifact.com/punditfact/statements/2016/jul/10/charles-ramsey/how-many-police-departments-are-us/" target="_blank" rel="noopener noreferrer">18,000 law enforcement agencies</a> in America shot civilians – a daunting, complex and fragmented task. Departments vary vastly in their approaches to collecting data on their interactions with the public, including their uses of force, rendering comparisons and analysis impossible. Even when departments do collect data, it’s often difficult for the public to access, parse and analyze for themselves.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6708,6 +6708,11 @@
         "readable-stream": "^2.3.6"
       }
     },
+    "focus-visible": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.1.0.tgz",
+      "integrity": "sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw=="
+    },
     "follow-redirects": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "chartjs-plugin-labels": "^1.1.0",
     "cloudinary-react": "^1.3.0",
     "downloadjs": "^1.4.7",
+    "focus-visible": "^5.1.0",
     "frontmatter-markdown-loader": "^2.0.0",
     "html-react-parser": "^0.7.0",
     "imagemin-mozjpeg": "^8.0.0",

--- a/pages/about.js
+++ b/pages/about.js
@@ -11,6 +11,7 @@ import BioBox from '../components/BioBox';
 import Volunteers from '../components/Volunteers';
 import DonorThumbnails from '../components/DonorThumbnails';
 import Parser from '../components/Parser';
+import VideoPlayer from '../components/VideoPlayer';
 import content from '../content/about-us.md';
 
 const {
@@ -33,6 +34,12 @@ const About = () => (
       <Primary>
         <h1>{title}</h1>
         <BlockQuote>{mission}</BlockQuote>
+
+        <VideoPlayer
+          url="https://res.cloudinary.com/texas-justice-initiative/video/upload/v1586367151/tji-intro-video-long-updated_i6rybk.mp4"
+          title="introVideo"
+        />
+
         <div dangerouslySetInnerHTML={{ __html: html }} />
 
         <h2 className="align--center spacing--large">{whoTitle}</h2>


### PR DESCRIPTION
We want to capture video plays in Google Analytics.

Unfortunately, we're not able to capture analytics with the [Cloudinary cloud-based player](https://cloudinary.com/documentation/video_player_how_to_embed#cloud_hosted_player) we're currently using. I explored self-hosting the Cloudinary player as well as using the popular [video.js](https://videojs.com/) player, but the implementation of either one seemed pretty cumbersome.

The solution I landed on in this PR was using the native [HTML5 `<video>` element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/video). I was a little worried about browser support, but it turns out that both the [`<video> element`](https://caniuse.com/#feat=video) and the [MPEG-4 format](https://caniuse.com/#feat=mpeg4) that we're using have very wide browser support.

With this PR in place, we'll fire a `play` event to Google Analytics each time a user plays the video. If a user stops and starts a video multiple times, we'll fire a play event each time, but Google Analytics will handle that gracefully with its [implicit counting](https://support.google.com/analytics/answer/1033068?hl=en).

> For example, if one user clicks the same button on a video 5 times, the total number of events associated with the video is 5, and the number of unique events is 1.

closes https://github.com/texas-justice-initiative/website-nextjs/issues/309