### PR TITLE
Add new content banner to CMS

### DIFF
--- a/components/Banner.js
+++ b/components/Banner.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Link from 'next/link';
+import content from '../content/new-content-banner.md';
 
 class Banner extends React.Component {
   constructor(props) {
     super(props);
     this.state = { hidden: true };
     this.dismiss = this.dismiss.bind(this);
-    this.dismissedKey = `${props.name}BannerDismissed`;
+    this.dismissedKey = `${content.attributes.name}BannerDismissed`;
   }
 
   componentDidMount() {
@@ -24,14 +24,20 @@ class Banner extends React.Component {
 
   render() {
     const { hidden } = this.state;
-    const { path, copy } = this.props;
+    const {
+      attributes: { show, text, path },
+    } = content;
+
+    if (!show) {
+      return null;
+    }
 
     return (
       <StyledBanner className={hidden ? 'hidden' : ''}>
         <Callout>New</Callout>
         <Link href={path}>
           <a href={path} onClick={this.dismiss}>
-            {copy}
+            {text}
           </a>
         </Link>
         <DismissButton onClick={this.dismiss}>ⓧ</DismissButton>
@@ -93,9 +99,3 @@ const DismissButton = styled.button`
   color: ${props => props.theme.colors.white};
   text-decoration: none;
 `;
-
-Banner.propTypes = {
-  name: PropTypes.string.isRequired,
-  path: PropTypes.string.isRequired,
-  copy: PropTypes.string.isRequired,
-};

--- a/components/Page.js
+++ b/components/Page.js
@@ -30,11 +30,7 @@ class Page extends Component {
           <Meta />
           <GoogleAnalytics />
           <GlobalStyle />
-          <Banner
-            name="covidMap"
-            path="/publications/covid-deaths-in-texas"
-            copy="TJI map shows COVID-19-related deaths in Texas prisons and jails"
-          />
+          <Banner />
           <Header onMenuToggle={this.onHeaderMenuToggle} theme={theme} />
           <div>{this.props.children}</div>
           <Footer />

--- a/content/new-content-banner.md
+++ b/content/new-content-banner.md
@@ -1,0 +1,6 @@
+---
+show: true
+name: covidMap
+text: TJI map shows COVID-19-related deaths in Texas prisons and jails
+path: /publications/covid-deaths-in-texas
+---

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: github
   repo: texas-justice-initiative/website-nextjs
-  branch: master
+  branch: new-content-banner-to-cms
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow
@@ -149,6 +149,14 @@ collections:
       file: "content/about-sidebar.md"
       fields:
         - {label: "Body", name: "body", widget: "markdown"}
+    - label: "New content banner"
+      name: "newContentBanner"
+      file: "content/new-content-banner.md"
+      fields:
+        - {label: "Show banner?", name: "show", widget: "boolean"}
+        - {label: "Name of content (used to check if user has already dismissed banner for this content)", name: "name", widget: "string"}
+        - {label: "Banner text", name: "text", widget: "string"}
+        - {label: "Relative path to content (e.g. /publications/covid-deaths-in-texas)", name: "path", widget: "string"}
 media_library:
   name: "cloudinary"
   config:

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: github
   repo: texas-justice-initiative/website-nextjs
-  branch: new-content-banner-to-cms
+  branch: master
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow


### PR DESCRIPTION
This PR makes the new content banner editable in the Netlify CMS.

Currently, we're using that banner to highlight the COVID map. We'd like to be able to turn that banner off in a week or so, and then later, we'd like to turn it back on with a reference to the OIS report. With this PR in place, we should be able to handle all of that through the CMS.

<img width="744" alt="Screen Shot 2020-08-02 at 6 01 17 PM" src="https://user-images.githubusercontent.com/7942714/89136781-3f709500-d4ea-11ea-81cf-fff99ef3e809.png">

supports https://github.com/texas-justice-initiative/website-nextjs/issues/347
