### PR TITLE
Build page for OIS report

### DIFF
--- a/content/publications/officer-involved-shootings-in-texas.md
+++ b/content/publications/officer-involved-shootings-in-texas.md
@@ -1,0 +1,6 @@
+---
+title: "Officer-Involved Shootings in Texas: 2016-2019"
+---
+In 2015, Texas lawmakers passed legislation requiring law enforcement agencies to file a simple report within 30 days of an officer-involved shooting, whether fatal or not. The reports began to trickle into the [Office of the Attorney General (OAG)](https://texasattorneygeneral.gov/). The law was amended in 2017 to impose potential penalties – up to a [$1,000-a-day fine](https://capitol.texas.gov/tlodocs/85R/billtext/pdf/HB00245F.pdf#navpanes=0) – for agencies that do not properly file their reports.
+
+This report analyzes data pulled from the officer-involved shooting reports reflecting shootings that took place from Jan. 1, 2016 to Dec. 31, 2019. In this document, TJI also drills into the shootings of civilians by Texas officers, and the shootings of Texas officers to reveal findings about the demography of these shootings – including race – as well as characteristics like where the shootings occur, who is more likely to survive a shooting, and more.

--- a/content/publications/officer-involved-shootings-in-texas.md
+++ b/content/publications/officer-involved-shootings-in-texas.md
@@ -1,5 +1,6 @@
 ---
 title: "Officer-Involved Shootings in Texas: 2016-2019"
+showSidebar: true
 ---
 In 2015, Texas lawmakers passed legislation requiring law enforcement agencies to file a simple report within 30 days of an officer-involved shooting, whether fatal or not. The reports began to trickle into the [Office of the Attorney General (OAG)](https://texasattorneygeneral.gov/). The law was amended in 2017 to impose potential penalties – up to a [$1,000-a-day fine](https://capitol.texas.gov/tlodocs/85R/billtext/pdf/HB00245F.pdf#navpanes=0) – for agencies that do not properly file their reports.
 

--- a/next.config.js
+++ b/next.config.js
@@ -13,6 +13,9 @@ const nextConfig = {
       '/data': { page: '/data' },
       '/related-organizations': { page: '/related-organizations' },
       '/publications': { page: '/publications' },
+      '/publications/officer-involved-shootings-in-texas': {
+        page: '/publications/officer-involved-shootings-in-texas',
+      },
       '/publications/pre-conviction-deaths-in-texas-jails': {
         page: '/publications/pre-conviction-deaths-in-texas-jails',
       },

--- a/pages/publications/officer-involved-shootings-in-texas.js
+++ b/pages/publications/officer-involved-shootings-in-texas.js
@@ -1,0 +1,29 @@
+/* eslint-disable react/no-danger */
+
+import Head from 'next/head';
+import React from 'react';
+import Layout from '../../components/Layout';
+import Primary from '../../components/Primary';
+import Sidebar from '../../components/Sidebar';
+import content from '../../content/publications/officer-involved-shootings-in-texas.md';
+
+const {
+  html,
+  attributes: { title, showSidebar },
+} = content;
+
+const Page = () => (
+  <React.Fragment>
+    <Head>
+      <title>Texas Justice Initiative | {title}</title>
+    </Head>
+    <Layout>
+      <Primary>
+        <h1>{title}</h1>
+        <div dangerouslySetInnerHTML={{ __html: html }} />
+      </Primary>
+      {showSidebar && <Sidebar />}
+    </Layout>
+  </React.Fragment>
+);
+export default Page;

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: github
   repo: texas-justice-initiative/website-nextjs
-  branch: ois-page
+  branch: master
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: github
   repo: texas-justice-initiative/website-nextjs
-  branch: master
+  branch: ois-page
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow
@@ -138,6 +138,15 @@ collections:
     - label: "Donation Page"
       name: "donate"
       file: "content/donate.md"
+      fields:
+        - {label: "Title", name: "title", widget: "string"}
+        - {label: "Body", name: "body", widget: "markdown"}
+  - name: "publications"
+    label: "Publications"
+    files:
+    - label: "Officer-involved shootings report"
+      name: "oisReport"
+      file: "content/publications/officer-involved-shootings-in-texas.md"
       fields:
         - {label: "Title", name: "title", widget: "string"}
         - {label: "Body", name: "body", widget: "markdown"}

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -149,6 +149,7 @@ collections:
       file: "content/publications/officer-involved-shootings-in-texas.md"
       fields:
         - {label: "Title", name: "title", widget: "string"}
+        - {label: "Show sidebar?", name: "showSidebar", widget: "boolean"}
         - {label: "Body", name: "body", widget: "markdown"}
   - name: "components"
     label: "Components"


### PR DESCRIPTION
@hongsups's OIS report is nearing completion! We'd like for it to live on a page on TJI's site that is linked through the publications page.

This PR adds a new page for the OIS report. It's not linked anywhere on the website yet, so we can merge this PR and continue to tweak the content through the CMS (for example, we'll want to add a link to the PDF of the report itself, and maybe include a thumbnail of the cover). Once we're ready to launch the report, we can add a link to the publications page via the CMS.

You can take a look at how the page looks right now in the deploy preview:

https://deploy-preview-388--texasjusticeinitiative.netlify.app/publications/officer-involved-shootings-in-texas

closes https://github.com/texas-justice-initiative/website-nextjs/issues/361