### PR TITLE
Show older news stories

### DIFF
--- a/components/homepage/HomepageNewsFeed.js
+++ b/components/homepage/HomepageNewsFeed.js
@@ -78,6 +78,11 @@ class HomepageNewsFeed extends React.Component {
         </div>
         <div className="column-right">
           <NewsFeed page={1} perPage={4} />
+          <Link href="/news?page=2">
+            <a href="/news?page=2" style={{ float: 'right' }}>
+              See more of what we’re reading…
+            </a>
+          </Link>
         </div>
       </Wrapper>
     );

--- a/pages/news.js
+++ b/pages/news.js
@@ -25,12 +25,16 @@ const News = () => {
   const pageLinks = [];
   for (let pageNumber = 1; pageNumber <= Math.ceil(news.length / perPage); pageNumber += 1) {
     if (pageNumber === page) {
-      pageLinks.push(<PageNumber className="current">{pageNumber}</PageNumber>);
+      pageLinks.push(
+        <PageNumber className="current" key={pageNumber}>
+          {pageNumber}
+        </PageNumber>
+      );
     } else {
       const pagePath = `/news?page=${pageNumber}`;
 
       pageLinks.push(
-        <Link href={pagePath}>
+        <Link href={pagePath} key={pageNumber}>
           <a href={pagePath} style={{ textDecoration: 'none' }}>
             <PageNumber>{pageNumber}</PageNumber>
           </a>

--- a/pages/news.js
+++ b/pages/news.js
@@ -14,16 +14,18 @@ const {
 } = content;
 
 const News = () => {
+  const perPage = 5;
+  const pageCount = Math.ceil(news.length / perPage);
+
   const router = useRouter();
   let { page } = router.query;
   page = parseInt(page);
-  if (Number.isNaN(page) || page < 1) {
+  if (Number.isNaN(page) || page < 1 || page > pageCount) {
     page = 1;
   }
 
-  const perPage = 5;
   const pageLinks = [];
-  for (let pageNumber = 1; pageNumber <= Math.ceil(news.length / perPage); pageNumber += 1) {
+  for (let pageNumber = 1; pageNumber <= pageCount; pageNumber += 1) {
     if (pageNumber === page) {
       pageLinks.push(
         <PageNumber className="current" key={pageNumber}>

--- a/pages/news.js
+++ b/pages/news.js
@@ -1,5 +1,8 @@
 import React from 'react';
+import styled from 'styled-components';
 import Head from 'next/head';
+import { useRouter } from 'next/router';
+import Link from 'next/link';
 import Layout from '../components/Layout';
 import Primary from '../components/Primary';
 import Sidebar from '../components/Sidebar';
@@ -7,20 +10,63 @@ import NewsFeed from '../components/NewsFeed';
 import content from '../content/newsfeed.md';
 
 const {
-  attributes: { heading },
+  attributes: { heading, news },
 } = content;
 
-const News = () => (
-  <React.Fragment>
-    <Head>
-      <title>Texas Justice Initiative | {heading}</title>
-    </Head>
-    <Layout>
-      <Primary>
-        <NewsFeed page={1} perPage={20} />
-      </Primary>
-      <Sidebar />
-    </Layout>
-  </React.Fragment>
-);
+const News = () => {
+  const router = useRouter();
+  let { page } = router.query;
+  page = parseInt(page);
+  if (Number.isNaN(page) || page < 1) {
+    page = 1;
+  }
+
+  const perPage = 5;
+  const pageLinks = [];
+  for (let pageNumber = 1; pageNumber <= Math.ceil(news.length / perPage); pageNumber += 1) {
+    if (pageNumber === page) {
+      pageLinks.push(<PageNumber className="current">{pageNumber}</PageNumber>);
+    } else {
+      const pagePath = `/news?page=${pageNumber}`;
+
+      pageLinks.push(
+        <Link href={pagePath}>
+          <a href={pagePath} style={{ textDecoration: 'none' }}>
+            <PageNumber>{pageNumber}</PageNumber>
+          </a>
+        </Link>
+      );
+    }
+  }
+
+  return (
+    <React.Fragment>
+      <Head>
+        <title>Texas Justice Initiative | {heading}</title>
+      </Head>
+      <Layout>
+        <Primary>
+          <NewsFeed page={page} perPage={perPage} />
+          <div style={{ textAlign: 'center' }}>{pageLinks}</div>
+        </Primary>
+        <Sidebar />
+      </Layout>
+    </React.Fragment>
+  );
+};
 export default News;
+
+const PageNumber = styled.span`
+  padding: 0.5em 0.8em;
+  border: 1px solid ${props => props.theme.colors.grayLight};
+  margin-left: -1px;
+  color: ${props => props.theme.colors.primaryBlue};
+  background-color: ${props => props.theme.colors.white};
+  transition: all 0.35s;
+
+  &.current,
+  &:hover {
+    color: ${props => props.theme.colors.white};
+    background-color: ${props => props.theme.colors.primaryBlue};
+  }
+`;


### PR DESCRIPTION
We currently feature four news stories at a time on our homepage, and older news stories disappear as new ones are added. This PR adds a link to a new page that allows users to view all of those older news stories.

![older-news-stories](https://user-images.githubusercontent.com/7942714/90965929-9df1b900-e481-11ea-9e8a-7b8d04b37555.gif)

closes https://github.com/texas-justice-initiative/website-nextjs/issues/360