### PR TITLE
Add new newsfeed stories to top of list

### DIFF
--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -18,9 +18,11 @@ collections:
       fields:
         - {label: "Heading", name: "heading", widget: "string"}
         - {label: "Intro", name: "intro", widget: "markdown"}
-        - label: "News"
+        - label: "Stories"
+          label_singular: "Story"
           name: "news"
           widget: "list"
+          add_to_top: true
           fields:
             - {label: "Title", name: "title", widget: "string"}
             - {label: "Publish Date", name: "date", widget: "datetime", format: "YYYY-MM-DD", timeFormat: false, pickerUtc: true}


### PR DESCRIPTION
Currently, when we add a new newsfeed story in the CMS, the new story is added to the bottom of the list. Since we generally want new stories to appear at the top of the feed, that means we need to drag the new story to the top of the list, which is becoming more tedious as we add new stories.

This change takes advantage of the new `add_to_top` configuration option for lists in Netlify CMS (see https://github.com/netlify/netlify-cms/pull/4465) to have new newsfeed stories added to the top of the list.

closes https://github.com/texas-justice-initiative/website-nextjs/issues/428