### PR TITLE
Reduce font sizes on /interactive

### DIFF
--- a/components/DataTable.js
+++ b/components/DataTable.js
@@ -75,11 +75,6 @@ const Container = styled.div`
         color: ${props => props.theme.colors.black};
         font-weight: ${props => props.theme.fontWeights.bold};
         letter-spacing: ${props => props.theme.letterSpacings.medium};
-
-        @media (min-width: ${props => props.theme.medium}) {
-          font-size: ${props => props.theme.fontSizes.xl};
-          line-height: ${props => props.theme.lineHeights.lg};
-        }
       }
 
       .dataset-date {
@@ -98,8 +93,8 @@ const Container = styled.div`
 
         @media (min-width: ${props => props.theme.medium}) {
           margin-bottom: 0;
-          font-size: ${props => props.theme.fontSizes.xl};
-          line-height: ${props => props.theme.lineHeights.lg};
+          font-size: ${props => props.theme.fontSizes.md};
+          line-height: ${props => props.theme.lineHeights.md};
         }
       }
 
@@ -108,19 +103,12 @@ const Container = styled.div`
 
         @media (min-width: ${props => props.theme.medium}) {
           display: block;
-          font-size: ${props => props.theme.fontSizes.xl};
-          line-height: ${props => props.theme.lineHeights.lg};
         }
       }
 
       .dataset-link {
         font-weight: ${props => props.theme.fontWeights.bold};
         text-transform: uppercase;
-
-        @media (min-width: ${props => props.theme.medium}) {
-          font-size: ${props => props.theme.fontSizes.lg};
-          line-height: ${props => props.theme.lineHeights.md};
-        }
       }
     }
   }


### PR DESCRIPTION
The font sizes in the datasets table on the new `/interactive` page on desktop screens were a little larger than we wanted. This PR reduces those font sizes [per Julia's recommendation](https://txjusticeinitiative.slack.com/archives/CB4NTCZN0/p1607283614003500?thread_ts=1607279853.002000&cid=CB4NTCZN0).