### PR TITLE
Switch hero image on dataset landing page to png

### DIFF
--- a/components/Hero.js
+++ b/components/Hero.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 const Hero = ({ title, description }) => (
-  <HeroContainer img={require('../images/map-desktop.svg')}>
+  <HeroContainer img={require('../images/map-desktop.png')}>
     <div className="content-container">
       <h1 className="title">{title}</h1>
       <h2 className="description">{description}</h2>


### PR DESCRIPTION
Switching svg to png for now, based on feedback that the image was loading slowly for multiple people. Potentially want to create/replace with a smaller svg later.