### PR TITLE
Show thank you message after successful donation

### DIFF
--- a/components/forms/PaypalButton.js
+++ b/components/forms/PaypalButton.js
@@ -41,7 +41,7 @@ class PaypalButton extends React.Component {
   }
 
   render() {
-    const { total, currency, env, commit, client } = this.props;
+    const { total, currency, env, commit, client, onSuccess } = this.props;
     const { showButton } = this.state;
 
     const payment = () =>
@@ -83,11 +83,12 @@ class PaypalButton extends React.Component {
 export default scriptLoader('https://www.paypalobjects.com/api/checkout.js')(PaypalButton);
 
 PaypalButton.propTypes = {
-  total: PropTypes.number,
+  total: PropTypes.string,
   currency: PropTypes.string,
   env: PropTypes.string.isRequired,
   commit: PropTypes.bool,
   client: PropTypes.object,
   isScriptLoaded: PropTypes.bool,
   isScriptLoadSucceed: PropTypes.bool,
+  onSuccess: PropTypes.func.isRequired,
 };

--- a/components/forms/ReviewForm.js
+++ b/components/forms/ReviewForm.js
@@ -37,7 +37,7 @@ class ReviewForm extends React.Component {
   }
 
   render() {
-    const { formState, total, returnToForm } = this.props;
+    const { formState, total, returnToForm, onSuccess } = this.props;
     const { state } = this;
     const { params, isLoaded } = state;
     const { env, client } = params;
@@ -76,7 +76,7 @@ class ReviewForm extends React.Component {
             <b>Donation Amount:</b> ${total}
           </li>
         </ul>
-        <PaypalButton env={env} client={client} commit currency="USD" total={total} />
+        <PaypalButton env={env} client={client} commit currency="USD" total={total} onSuccess={onSuccess} />
       </DonationReview>
     );
   }
@@ -86,8 +86,9 @@ export default ReviewForm;
 
 ReviewForm.propTypes = {
   formState: PropTypes.object.isRequired,
-  total: PropTypes.number.isRequired,
+  total: PropTypes.string.isRequired,
   returnToForm: PropTypes.func.isRequired,
+  onSuccess: PropTypes.func.isRequired,
 };
 
 const DonationReview = styled.div`

--- a/content/donation-thank-you.md
+++ b/content/donation-thank-you.md
@@ -1,0 +1,7 @@
+## Thank you!
+
+Thank you for your donation to Texas Justice Initiative! Your generous gift of ${total} will help us collect, analyze, publish, and provide oversight for criminal justice data throughout Texas.
+
+Texas Justice Initiative is a registered 501(c)(3) non-profit organization (EIN 82-2693130). No goods or services were rendered in exchange for your contribution.
+
+Once again, thank you for your donation! It‘s because of supporters like you that we can continue to provide vital criminal justice data to the public for free.

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -48,6 +48,13 @@ class Page extends React.Component {
     this.handleInputChange = this.handleInputChange.bind(this);
     this.submitForReview = this.submitForReview.bind(this);
     this.returnToForm = this.returnToForm.bind(this);
+    this.onSuccess = this.onSuccess.bind(this);
+  }
+
+  onSuccess() {
+    this.setState({
+      formStep: 3,
+    });
   }
 
   // Handler for form inputs
@@ -167,7 +174,31 @@ class Page extends React.Component {
                 formSubmitted={formSubmitted}
               />
             )}
-            {formStep === 2 && <ReviewForm formState={formState} total={total} returnToForm={this.returnToForm} />}
+            {formStep === 2 && (
+              <ReviewForm
+                formState={formState}
+                total={total}
+                returnToForm={this.returnToForm}
+                onSuccess={this.onSuccess}
+              />
+            )}
+            {formStep === 3 && (
+              <div>
+                <h2>Thank you!</h2>
+                <p>
+                  Thank you for your donation to Texas Justice Initiative! Your generous gift of ${total} will help us
+                  collect, analyze, publish, and provide oversight for criminal justice data throughout Texas.
+                </p>
+                <p>
+                  Texas Justice Initiative is a registered 501(c)(3) non-profit organization (EIN 82-2693130). No goods
+                  or services were rendered in exchange for your contribution.
+                </p>
+                <p>
+                  Once again, thank you for your donation! It‘s because of supporters like you that we can continue to
+                  provide vital criminal justice data to the public for free.
+                </p>
+              </div>
+            )}
           </Primary>
           <Sidebar />
         </Layout>

--- a/pages/donate.js
+++ b/pages/donate.js
@@ -8,6 +8,7 @@ import Sidebar from '../components/Sidebar';
 import DonationForm from '../components/forms/DonationForm';
 import ReviewForm from '../components/forms/ReviewForm';
 import content from '../content/donate.md';
+import thankYouContent from '../content/donation-thank-you.md';
 
 const {
   html,
@@ -149,6 +150,9 @@ class Page extends React.Component {
 
   render() {
     const { formStep, formSubmitted, firstName, lastName, email, amount, includeProcessingFee, total } = this.state;
+    let { html: thankYouHtml } = thankYouContent;
+    thankYouHtml = thankYouHtml.replace('{total}', total);
+
     const formState = {
       firstName,
       lastName,
@@ -182,23 +186,7 @@ class Page extends React.Component {
                 onSuccess={this.onSuccess}
               />
             )}
-            {formStep === 3 && (
-              <div>
-                <h2>Thank you!</h2>
-                <p>
-                  Thank you for your donation to Texas Justice Initiative! Your generous gift of ${total} will help us
-                  collect, analyze, publish, and provide oversight for criminal justice data throughout Texas.
-                </p>
-                <p>
-                  Texas Justice Initiative is a registered 501(c)(3) non-profit organization (EIN 82-2693130). No goods
-                  or services were rendered in exchange for your contribution.
-                </p>
-                <p>
-                  Once again, thank you for your donation! It‘s because of supporters like you that we can continue to
-                  provide vital criminal justice data to the public for free.
-                </p>
-              </div>
-            )}
+            {formStep === 3 && <div dangerouslySetInnerHTML={{ __html: thankYouHtml }} />}
           </Primary>
           <Sidebar />
         </Layout>

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: github
   repo: texas-justice-initiative/website-nextjs
-  branch: thank-you-after-donation
+  branch: master
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   # Navigate to localhost:3333/static/admin/index.html to view Netlify CMS locally. 
   name: github
   repo: texas-justice-initiative/website-nextjs
-  branch: master
+  branch: thank-you-after-donation
   # This line should *not* be indented
 media_folder: static/images/uploads
 publish_mode: editorial_workflow
@@ -189,6 +189,11 @@ collections:
         - {label: "Name of content (used to check if user has already dismissed banner for this content)", name: "name", widget: "string"}
         - {label: "Banner text", name: "text", widget: "string"}
         - {label: "Relative path to content (e.g. /publications/covid-deaths-in-texas)", name: "path", widget: "string"}
+    - label: "Donation thank you content"
+      name: "donationThankYou"
+      file: "content/donation-thank-you.md"
+      fields:
+        - {label: "Body", name: "body", widget: "markdown"}
 media_library:
   name: "cloudinary"
   config:


### PR DESCRIPTION
Currently, after someone makes a donation to TJI through our website, we don't show any kind of confirmation that we received the donation.

This PR updates the donation flow to show a thank you message. It implements an [`onSuccess` function](https://github.com/texas-justice-initiative/website-nextjs/blob/f6554b486be0594feb31502d93e45a48345014e9/components/forms/PaypalButton.js#L70) that's currently called (but wasn't defined) after the donation [is successful](https://developer.paypal.com/docs/archive/checkout/integrate/?mark=get%20the%20code#3-execute-the-payment).

![demo](https://user-images.githubusercontent.com/7942714/102147817-37bde700-3e20-11eb-9c4c-d913dee81bc8.gif)

closes https://github.com/texas-justice-initiative/website-nextjs/issues/201