### PR TITLE
Ask users to agree to license before downloading data

### DIFF
--- a/components/Modal.js
+++ b/components/Modal.js
@@ -1,0 +1,101 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
+
+const Modal = props => {
+  const { title, description, button, children, onClose } = props;
+
+  // Allow esc key to close form
+  const handleKeyDown = event => {
+    if (event.key === 'Escape') {
+      onClose();
+    }
+  };
+
+  // Handles user declining to fill out form
+  const cancelForm = () => {
+    onClose();
+  };
+
+  return (
+    <Container onKeyDown={handleKeyDown} tabIndex={0}>
+      <div className="tji-modal">
+        <div className="tji-modal__close" role="button" tabIndex={0} onClick={cancelForm} onKeyDown={handleKeyDown}>
+          ⓧ
+        </div>
+        {title && <h2 className="tji-modal__title">{title}</h2>}
+        <div className="tji-modal__description">
+          {description && description}
+          {children && children}
+        </div>
+        <div className="tji-modal__actions">
+          {button && (
+            <button type="button" className="btn btn--primary" onClick={button.clickFunction}>
+              {button.text}
+            </button>
+          )}
+        </div>
+      </div>
+    </Container>
+  );
+};
+export default Modal;
+
+Modal.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  button: PropTypes.object,
+  children: PropTypes.element,
+  onClose: PropTypes.func,
+};
+
+const Container = styled.div`
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 97;
+  &::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: ${props => props.theme.colors.black};
+    opacity: 0.25;
+    z-index: 98;
+  }
+  .tji-modal {
+    background: ${props => props.theme.colors.white};
+    border-radius: 5px;
+    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.3);
+    padding: 4rem;
+    margin: 0 2rem;
+    z-index: 99;
+    width: 450px;
+    position: relative;
+  }
+  .tji-modal__title,
+  .tji-modal__actions {
+    text-align: center;
+  }
+  .tji-modal__actions {
+    margin-top: 2rem;
+  }
+  .tji-modal__description {
+    text-align: left;
+    margin: 2.4rem 0;
+  }
+  .tji-modal__close {
+    position: absolute;
+    top: 0.5rem;
+    right: 1rem;
+    color: ${props => props.theme.colors.gray};
+    cursor: pointer;
+  }
+`;

--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -56,7 +56,7 @@ class DataDownloadButton extends React.Component {
             <div>
               If you use TJI’s data, you must give TJI credit and adhere to TJI’s{' '}
               <a
-                href="https://github.com/texas-justice-initiative/data-processing"
+                href="https://github.com/texas-justice-initiative/data-processing/blob/master/DataUsageAgreement.md"
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/components/explore-the-data-page/DataDownloadButton.js
+++ b/components/explore-the-data-page/DataDownloadButton.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import Papa from 'papaparse';
 import download from 'downloadjs';
+import Modal from '../Modal';
 import SurveyModal from '../SurveyModal';
 
 class DataDownloadButton extends React.Component {
@@ -10,6 +11,7 @@ class DataDownloadButton extends React.Component {
     super(props);
 
     this.state = {
+      dataLicenseModalOpen: false,
       downloadStarted: false,
     };
   }
@@ -21,6 +23,7 @@ class DataDownloadButton extends React.Component {
     download(blob, fileName);
 
     this.setState({
+      dataLicenseModalOpen: false,
       downloadStarted: true,
     });
   }
@@ -28,7 +31,7 @@ class DataDownloadButton extends React.Component {
   render() {
     const { fileName, data } = this.props;
     const { state } = this;
-    const { downloadStarted } = state;
+    const { dataLicenseModalOpen, downloadStarted } = state;
 
     if (!data) {
       return <A className="btn btn--primary btn--chart-toggle btn--disabled">Download (CSV)</A>;
@@ -41,10 +44,29 @@ class DataDownloadButton extends React.Component {
           download={fileName}
           target="_blank"
           rel="noopener noreferrer"
-          onClick={() => this.startDownload(fileName)}
+          onClick={() => this.setState({ dataLicenseModalOpen: true })}
         >
           Download (CSV)
         </A>
+        {dataLicenseModalOpen && (
+          <Modal
+            button={{ text: 'Accept & Download', clickFunction: () => this.startDownload(fileName) }}
+            onClose={() => this.setState({ dataLicenseModalOpen: false })}
+          >
+            <div>
+              If you use TJI’s data, you must give TJI credit and adhere to TJI’s{' '}
+              <a
+                href="https://github.com/texas-justice-initiative/data-processing"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Data Access License Terms
+              </a>
+              . Pursuant to the License, you must always link back to the original TJI data set. Further, if you use the
+              data set, please tag us on social media when referring to data retrieved from this site.
+            </div>
+          </Modal>
+        )}
         {downloadStarted && <SurveyModal />}
       </React.Fragment>
     );


### PR DESCRIPTION
We want to make sure users agree to our data license before they download data from the Explore the Data page. This PR introduces a modal that we show after a user clicks the download button but before the download starts asking them to agree to the data license.

With this change in place, we'll still show the user the download the data survey after clicking "agree & continue" in the data license modal. We'll only show them the data license agreement (and not the download the data survey) for subsequent downloads.

closes https://github.com/texas-justice-initiative/website-nextjs/issues/500

## Demo

![demo](https://user-images.githubusercontent.com/7942714/104141024-62408880-5369-11eb-9203-7449d1a543f1.gif)
