### PR TITLE
Fetch default branch name in Netlify CMS config linter

### DIFF
--- a/.github/workflows/netlify_cms_config_validation.yml
+++ b/.github/workflows/netlify_cms_config_validation.yml
@@ -27,10 +27,6 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
           })
-          core.info(`context.repo.owner: ${context.repo.owner}`)
-          core.info(`context.repo.repo: ${context.repo.repo}`)
-          core.info(`repo.data: ${repo.data}`)
-          core.info(`repo.data.default_branch: ${repo.data.default_branch}`)
           const expectedBranch = repo.data.default_branch
 
           if (branch === expectedBranch) {

--- a/.github/workflows/netlify_cms_config_validation.yml
+++ b/.github/workflows/netlify_cms_config_validation.yml
@@ -29,8 +29,9 @@ jobs:
           })
           core.info(`context.repo.owner: ${context.repo.owner}`)
           core.info(`context.repo.repo: ${context.repo.repo}`)
-          core.info(`repo: ${repo}`)
-          const expectedBranch = repo.data[0].default_branch
+          core.info(`repo.data: ${repo.data}`)
+          core.info(`repo.data.default_branch: ${repo.data.default_branch}`)
+          const expectedBranch = repo.data.default_branch
 
           if (branch === expectedBranch) {
             core.info(`✅ ${CONFIG_PATH} looks good!`)

--- a/.github/workflows/netlify_cms_config_validation.yml
+++ b/.github/workflows/netlify_cms_config_validation.yml
@@ -21,9 +21,13 @@ jobs:
       with:
         script: |
           const parsedConfig = JSON.parse(process.env.CONFIG)
-          const { CONFIG_PATH } = process.env
+          const { CONFIG_PATH, GITHUB_REPOSITORY } = process.env
           const { branch } = parsedConfig.backend
-          const expectedBranch = "master"
+          const repo = await github.request("GET /repos/{owner}/{repo}", {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          })
+          const expectedBranch = repo.data[0].default_branch
 
           if (branch === expectedBranch) {
             core.info(`✅ ${CONFIG_PATH} looks good!`)

--- a/.github/workflows/netlify_cms_config_validation.yml
+++ b/.github/workflows/netlify_cms_config_validation.yml
@@ -21,12 +21,15 @@ jobs:
       with:
         script: |
           const parsedConfig = JSON.parse(process.env.CONFIG)
-          const { CONFIG_PATH, GITHUB_REPOSITORY } = process.env
+          const { CONFIG_PATH } = process.env
           const { branch } = parsedConfig.backend
           const repo = await github.request("GET /repos/{owner}/{repo}", {
             owner: context.repo.owner,
             repo: context.repo.repo,
           })
+          core.info(`context.repo.owner: ${context.repo.owner}`)
+          core.info(`context.repo.repo: ${context.repo.repo}`)
+          core.info(`repo: ${repo}`)
           const expectedBranch = repo.data[0].default_branch
 
           if (branch === expectedBranch) {


### PR DESCRIPTION
This removes a hardcoded reference to `master`, which unblocks us to change the default branch of this repository to `main` per https://github.com/texas-justice-initiative/website-nextjs/issues/505.