### PR TITLE
Move getGoogleMaps calls to componentDidMount where browser APIs are accessible

### DIFF
--- a/components/CovidMap.js
+++ b/components/CovidMap.js
@@ -321,11 +321,9 @@ class CovidMap extends React.Component {
     };
   }
 
-  componentWillMount() {
-    this.getGoogleMaps();
-  }
-
   componentDidMount() {
+    this.getGoogleMaps();
+
     const { googleSheetsKey, googleSheetsName } = this.state;
     fetchAPI();
     Tabletop.init({

--- a/components/OfficerMap.js
+++ b/components/OfficerMap.js
@@ -347,11 +347,9 @@ class OfficerMap extends React.Component {
     };
   }
 
-  componentWillMount() {
-    this.getGoogleMaps();
-  }
-
   componentDidMount() {
+    this.getGoogleMaps();
+
     const { googleSheetsKey, googleSheetsName } = this.state;
     fetchAPI();
     Tabletop.init({


### PR DESCRIPTION
Per [this very helpful StackOverflow answer](https://stackoverflow.com/a/55151122), `window` isn't accessible on the server side in `componentWillMount`, which raises the build errors detailed in https://github.com/texas-justice-initiative/website-nextjs/issues/504. This PR addresses them by moving calls to `window` to `componentDidMount`, where it is always accessible because that lifecycle event is only executed on the client.

closes https://github.com/texas-justice-initiative/website-nextjs/issues/504