### PR TITLE
Improve spacing for donor logos

### DIFF
--- a/components/DonorThumbnails.js
+++ b/components/DonorThumbnails.js
@@ -37,8 +37,7 @@ const Wrapper = styled.div`
     padding: 2rem;
 
     @media screen and (min-width: ${props => props.theme.medium}) {
-      width: 25%;
-      padding: 0 2rem;
+      width: 33%;
     }
 
     img {


### PR DESCRIPTION
Now that we have five donor logos on our about us page, the logo spacing on the desktop view became a little awkward. This PR addresses that by adding vertical padding between the rows of logos and limiting the number of logos per row on desktop to 3.

### Before

<img width="656" alt="Screen Shot 2021-03-25 at 7 19 23 PM" src="https://user-images.githubusercontent.com/7942714/112563469-0a79c100-8d9f-11eb-93f2-c32fa8b5e4cb.png">

### After

<img width="656" alt="Screen Shot 2021-03-25 at 7 19 29 PM" src="https://user-images.githubusercontent.com/7942714/112563478-0f3e7500-8d9f-11eb-815f-4c7f0f8ef863.png">

closes https://github.com/texas-justice-initiative/website-nextjs/issues/558