### PR TITLE
Pull 'last updated' dates on datasets from CMS content

### DIFF
--- a/data/datasets.js
+++ b/data/datasets.js
@@ -1,10 +1,17 @@
+import content from '../content/interactive.md';
+
 const INCOMPLETE_YEAR_NOTE = 'Data from the shaded year is incomplete.';
 const OIS_INCOMPLETE_YEARS = [2015];
 const CUST_DEATHS_INCOMPLETE_YEARS = [];
 
+const {
+  attributes: { datasets: cmsDatasets },
+} = content;
+const lastUpdatedFromSlug = slug => cmsDatasets.find(dataset => dataset.link === `datasets/${slug}`)?.date;
+
 export default {
   'custodial-deaths': {
-    lastUpdated: '4/1/2021',
+    lastUpdated: lastUpdatedFromSlug('custodial-deaths'),
     name: 'Deaths in Custody',
     slug: 'custodial-deaths',
     description: 'All deaths in custody in Texas since 2005, as reported to the Office of the Attorney General.',
@@ -47,7 +54,7 @@ export default {
     ],
   },
   'civilians-shot': {
-    lastUpdated: '4/1/2021',
+    lastUpdated: lastUpdatedFromSlug('civilians-shot'),
     name: 'Civilians Shot',
     slug: 'civilians-shot',
     description:
@@ -74,7 +81,7 @@ export default {
     ],
   },
   'officers-shot': {
-    lastUpdated: '4/1/2021',
+    lastUpdated: lastUpdatedFromSlug('officers-shot'),
     name: 'Officers Shot',
     slug: 'officers-shot',
     description:


### PR DESCRIPTION
On our [officers shot](https://texasjusticeinitiative.org/datasets/officers-shot), [civilians shot](http://localhost:3333/datasets/civilians-shot), and [deaths in custoday](http://localhost:3333/datasets/custodial-deaths) dataset pages, we currently have to manually update the [`lastUpdated` strings in `datasets.js`](https://github.com/texas-justice-initiative/website-nextjs/blob/370ef6c2c9a5a0fed95c90e7072aa850a6429557/data/datasets.js#L7) each time we update the data. This PR pulls last updated dates for those pages from the same content coming from the CMS that we use on our [interactive data tools page](https://texasjusticeinitiative.org/data).

supports https://github.com/texas-justice-initiative/website-nextjs/issues/125