### PR TITLE
Make header more accessible

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -10,7 +10,25 @@ class Header extends Component {
     super(props);
 
     this.state = { menuHidden: true };
+    this.aboutMenu = React.createRef();
+    this.handleEventOutsideAboutMenu = this.handleEventOutsideAboutMenu.bind(this);
   }
+
+  componentDidMount() {
+    document.addEventListener('focusin', this.handleEventOutsideAboutMenu);
+    document.addEventListener('mousedown', this.handleEventOutsideAboutMenu);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('focusin', this.handleEventOutsideAboutMenu);
+    document.removeEventListener('mousedown', this.handleEventOutsideAboutMenu);
+  }
+
+  handleEventOutsideAboutMenu = ({ target }) => {
+    if (!this.aboutMenu) return;
+    if (target === this.aboutMenu.current || this.aboutMenu.current.contains(target)) return;
+    this.hideAboutMenu();
+  };
 
   hideMenu = () => {
     this.setState(() => ({
@@ -18,8 +36,26 @@ class Header extends Component {
     }));
   };
 
+  showAboutMenu = () => {
+    if (!this.aboutMenu) return;
+    this.aboutMenu.current.setAttribute('open', 'open');
+  };
+
+  hideAboutMenu = () => {
+    if (!this.aboutMenu) return;
+    this.aboutMenu.current.removeAttribute('open');
+  };
+
+  handleMenuLinkClick = () => {
+    this.hideMenu();
+    this.hideAboutMenu();
+  };
+
   handleMenuLinkKeyDown = e => {
-    if (e.key === 'Escape') this.hideMenu();
+    if (e.key === 'Escape') {
+      this.hideMenu();
+      this.hideAboutMenu();
+    }
   };
 
   handleMenuToggle = () => {
@@ -56,46 +92,35 @@ class Header extends Component {
           </button>
           <nav className={menuHidden ? 'hidden main-menu-wrapper' : 'visible main-menu-wrapper'}>
             <ul>
-              <li className="has-submenu">
-                <button type="button" className="btn--link">
-                  About
-                </button>
-                <ul className="submenu">
-                  <li>
-                    <HeaderLink href="/about" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
-                      About Us
-                    </HeaderLink>
-                  </li>
-                  <li>
-                    <HeaderLink href="/about-the-data" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
-                      About the Data
-                    </HeaderLink>
-                  </li>
-                  <li>
-                    <HeaderLink
-                      href="/related-organizations"
-                      onClick={this.hideMenu}
-                      onKeyDown={this.handleMenuLinkKeyDown}
-                    >
-                      Related Organizations
-                    </HeaderLink>
-                  </li>
-                </ul>
+              <li className="desktop-about">
+                <details ref={this.aboutMenu}>
+                  <summary className="btn--link">About</summary>
+                  <ul>
+                    <AboutLinks onLinkClick={this.handleMenuLinkClick} onLinkKeyDown={this.handleMenuLinkKeyDown} />
+                  </ul>
+                </details>
               </li>
+              <div className="mobile-about">
+                <AboutLinks onLinkClick={this.handleMenuLinkClick} onLinkKeyDown={this.handleMenuLinkKeyDown} />
+              </div>
               <li>
-                <HeaderLink href="/data" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
+                <HeaderLink href="/data" onClick={this.handleMenuLinkClick} onKeyDown={this.handleMenuLinkKeyDown}>
                   Explore the Data
                 </HeaderLink>
               </li>
               <li>
-                <HeaderLink href="/publications" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
+                <HeaderLink
+                  href="/publications"
+                  onClick={this.handleMenuLinkClick}
+                  onKeyDown={this.handleMenuLinkKeyDown}
+                >
                   Publications
                 </HeaderLink>
               </li>
               <li>
                 <HeaderLink
                   href="/donate"
-                  onClick={this.hideMenu}
+                  onClick={this.handleMenuLinkClick}
                   onKeyDown={this.handleMenuLinkKeyDown}
                   className="btn btn--donate"
                 >
@@ -136,6 +161,37 @@ HeaderLink.propTypes = {
   onKeyDown: PropTypes.func.isRequired,
   className: PropTypes.string,
   children: PropTypes.string.isRequired,
+};
+
+class AboutLinks extends Component {
+  render() {
+    const { onLinkClick, onLinkKeyDown } = this.props;
+
+    return (
+      <React.Fragment>
+        <li>
+          <HeaderLink href="/about" onClick={onLinkClick} onKeyDown={onLinkKeyDown}>
+            About Us
+          </HeaderLink>
+        </li>
+        <li>
+          <HeaderLink href="/about-the-data" onClick={onLinkClick} onKeyDown={onLinkKeyDown}>
+            About the Data
+          </HeaderLink>
+        </li>
+        <li>
+          <HeaderLink href="/related-organizations" onClick={onLinkClick} onKeyDown={onLinkKeyDown}>
+            Related Organizations
+          </HeaderLink>
+        </li>
+      </React.Fragment>
+    );
+  }
+}
+
+AboutLinks.propTypes = {
+  onLinkClick: PropTypes.func.isRequired,
+  onLinkKeyDown: PropTypes.func.isRequired,
 };
 
 const StyledHeader = styled.header`
@@ -265,10 +321,6 @@ const StyledHeader = styled.header`
         @media (min-width: ${props => props.theme.medium}) {
           display: inline-block;
         }
-
-        &.has-submenu:hover > ul {
-          display: block;
-        }
       }
 
       ul {
@@ -277,7 +329,6 @@ const StyledHeader = styled.header`
 
         @media (min-width: ${props => props.theme.medium}) {
           text-align: left;
-          display: none;
           width: 20rem;
           position: absolute;
           margin-top: 4rem;
@@ -356,6 +407,32 @@ const StyledHeader = styled.header`
 
     @media (min-width: ${props => props.theme.medium}) {
       margin-left: 2rem;
+    }
+  }
+
+  details {
+    summary {
+      list-style: none;
+
+      &::-webkit-details-marker {
+        display: none;
+      }
+    }
+  }
+
+  .desktop-about {
+    display: none;
+
+    @media (min-width: ${props => props.theme.medium}) {
+      display: block;
+    }
+  }
+
+  .mobile-about {
+    display: block;
+
+    @media (min-width: ${props => props.theme.medium}) {
+      display: none;
     }
   }
 `;

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars, global-require, jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions, react/destructuring-assignment */
+/* eslint-disable no-unused-vars, global-require, react/destructuring-assignment */
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -12,14 +12,17 @@ class Header extends Component {
     this.state = { menuHidden: true };
   }
 
-  componentDidUpdate(prevProps, prevState, snapshot) {
-    if (this.state.menuHidden !== prevState.menuHidden) {
-      this.props.onMenuToggle(this.state.menuHidden);
-    }
-  }
+  hideMenu = () => {
+    this.setState(() => ({
+      menuHidden: true,
+    }));
+  };
+
+  handleMenuLinkKeyDown = e => {
+    if (e.key === 'Escape') this.hideMenu();
+  };
 
   handleMenuToggle = e => {
-    // console.log(e.target);
     if (window.innerWidth <= parseInt(this.props.theme.medium)) {
       this.setState(prevState => ({
         menuHidden: !prevState.menuHidden,
@@ -47,10 +50,7 @@ class Header extends Component {
           >
             Menu
           </button>
-          <nav
-            className={this.state.menuHidden ? 'hidden main-menu-wrapper' : 'visible main-menu-wrapper'}
-            onClick={this.handleMenuToggle}
-          >
+          <nav className={this.state.menuHidden ? 'hidden main-menu-wrapper' : 'visible main-menu-wrapper'}>
             <ul>
               <li className="has-submenu">
                 <button type="button" className="btn--link">
@@ -58,36 +58,45 @@ class Header extends Component {
                 </button>
                 <ul className="submenu">
                   <li>
-                    <Link href="/about">
-                      <a>About Us</a>
-                    </Link>
+                    <HeaderLink href="/about" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
+                      About Us
+                    </HeaderLink>
                   </li>
                   <li>
-                    <Link href="/about-the-data">
-                      <a>About the Data</a>
-                    </Link>
+                    <HeaderLink href="/about-the-data" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
+                      About the Data
+                    </HeaderLink>
                   </li>
                   <li>
-                    <Link href="/related-organizations">
-                      <a>Related Organizations</a>
-                    </Link>
+                    <HeaderLink
+                      href="/related-organizations"
+                      onClick={this.hideMenu}
+                      onKeyDown={this.handleMenuLinkKeyDown}
+                    >
+                      Related Organizations
+                    </HeaderLink>
                   </li>
                 </ul>
               </li>
               <li>
-                <Link href="/data">
-                  <a>Explore the Data</a>
-                </Link>
+                <HeaderLink href="/data" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
+                  Explore the Data
+                </HeaderLink>
               </li>
               <li>
-                <Link href="/publications">
-                  <a>Publications</a>
-                </Link>
+                <HeaderLink href="/publications" onClick={this.hideMenu} onKeyDown={this.handleMenuLinkKeyDown}>
+                  Publications
+                </HeaderLink>
               </li>
               <li>
-                <Link href="/donate">
-                  <a className="btn btn--donate">Donate</a>
-                </Link>
+                <HeaderLink
+                  href="/donate"
+                  onClick={this.hideMenu}
+                  onKeyDown={this.handleMenuLinkKeyDown}
+                  className="btn btn--donate"
+                >
+                  Donate
+                </HeaderLink>
               </li>
             </ul>
           </nav>
@@ -100,8 +109,29 @@ class Header extends Component {
 export default Header;
 
 Header.propTypes = {
-  onMenuToggle: PropTypes.func.isRequired,
   theme: PropTypes.object.isRequired,
+};
+
+class HeaderLink extends Component {
+  render() {
+    const { href, onClick, onKeyDown, className, children } = this.props;
+
+    return (
+      <Link href={href}>
+        <a href={href} onClick={onClick} onKeyDown={onKeyDown} className={className}>
+          {children}
+        </a>
+      </Link>
+    );
+  }
+}
+
+HeaderLink.propTypes = {
+  href: PropTypes.string.isRequired,
+  onClick: PropTypes.func.isRequired,
+  onKeyDown: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  children: PropTypes.string.isRequired,
 };
 
 const StyledHeader = styled.header`

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-unused-vars, global-require, react/destructuring-assignment */
+/* eslint-disable global-require */
 
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
@@ -22,8 +22,10 @@ class Header extends Component {
     if (e.key === 'Escape') this.hideMenu();
   };
 
-  handleMenuToggle = e => {
-    if (window.innerWidth <= parseInt(this.props.theme.medium)) {
+  handleMenuToggle = () => {
+    const { theme } = this.props;
+
+    if (window.innerWidth <= parseInt(theme.medium)) {
       this.setState(prevState => ({
         menuHidden: !prevState.menuHidden,
       }));
@@ -31,6 +33,8 @@ class Header extends Component {
   };
 
   render() {
+    const { menuHidden } = this.state;
+
     return (
       <StyledHeader>
         <div className="inner-wrapper">
@@ -50,7 +54,7 @@ class Header extends Component {
           >
             Menu
           </button>
-          <nav className={this.state.menuHidden ? 'hidden main-menu-wrapper' : 'visible main-menu-wrapper'}>
+          <nav className={menuHidden ? 'hidden main-menu-wrapper' : 'visible main-menu-wrapper'}>
             <ul>
               <li className="has-submenu">
                 <button type="button" className="btn--link">


### PR DESCRIPTION
It's currently not possible to access any of the links in our about menu in the header navigation using just the keyboard. According to https://webaim.org/techniques/keyboard/:

> Keyboard accessibility is one of the most important aspects of web accessibility. Many users with motor disabilities rely on a keyboard. Some people have tremors which don't allow for fine muscle control. Others have little or no use of their hands, or no hands at all. In addition to traditional keyboards, some users may use modified keyboards or other hardware that mimics the functionality of a keyboard. Blind users also typically use a keyboard for navigation. Users without disabilities may use a keyboard for navigation because of preference or efficiency.

This PR makes the about links accessible via keyboard navigation using a `<details>` element, which is [a popular pattern at GitHub](https://css-tricks.com/using-details-for-menus-and-dialogs-is-an-interesting-idea/). While I was here, I addressed some linter ignore statements, which included more accessibility fixes. 

### Demo


https://user-images.githubusercontent.com/7942714/115976106-76c31e00-a51f-11eb-85c4-f35727e0e11e.mov



closes https://github.com/texas-justice-initiative/website-nextjs/issues/591