### PR TITLE
629/add license language

### DIFF
--- a/content/interactive.md
+++ b/content/interactive.md
@@ -3,7 +3,12 @@ title: Interactive data tools
 description: |-
   A collection of open datasets to help you make sense of the complex
     criminal justice systems in Texas.
-usage: These are the TJI[ terms of use.](#)
+usage: "**Users:** If you use TJI’s data, you must give TJI credit and adhere to
+  [TJI’s Data Access License
+  Terms](https://github.com/texas-justice-initiative/data-processing/blob/maste\
+  r/DataUsageAgreement.md). Pursuant to the License, you must always link back
+  to the original TJI data set. Further, if you use the data set, please tag us
+  on social media when referring to data retrieved from this site."
 datasets:
   - title: Shootings of Texas law enforcement officers
     description: Data on law enforcement officers injured or killed in shootings

--- a/content/interactive.md
+++ b/content/interactive.md
@@ -3,6 +3,7 @@ title: Interactive data tools
 description: |-
   A collection of open datasets to help you make sense of the complex
     criminal justice systems in Texas.
+usage: These are the TJI[ terms of use.](#)
 datasets:
   - title: Shootings of Texas law enforcement officers
     description: Data on law enforcement officers injured or killed in shootings

--- a/pages/data.js
+++ b/pages/data.js
@@ -5,6 +5,7 @@ import Primary from '../components/Primary';
 import Hero from '../components/Hero';
 import DataTable from '../components/DataTable';
 import content from '../content/interactive.md';
+import styled from 'styled-components';
 import Parser from '../components/Parser';
 
 const {
@@ -23,10 +24,22 @@ const Page = () => (
     <Layout fullWidth flexColumn>
       <Hero title={title} description={description} />
       <Primary>
-        <Parser>{md.render(usage)}</Parser>
+        {usage.length > 0 && (
+          <Usage id="data-usage">
+            <Parser>{md.render(usage)}</Parser>
+          </Usage>
+        )}
         <DataTable datasets={datasets} />
       </Primary>
     </Layout>
   </React.Fragment>
 );
 export default Page;
+
+const Usage = styled.div`
+  padding-top: 2rem;
+
+  p {
+    margin: 0;
+  }
+`;

--- a/pages/data.js
+++ b/pages/data.js
@@ -23,12 +23,12 @@ const Page = () => (
     </Head>
     <Layout fullWidth flexColumn>
       <Hero title={title} description={description} />
+    </Layout>
+    <Layout>
       <Primary>
-        {usage.length > 0 && (
-          <Usage id="data-usage">
-            <Parser>{md.render(usage)}</Parser>
-          </Usage>
-        )}
+        <Usage id="data-usage">
+          <Parser>{md.render(usage)}</Parser>
+        </Usage>
         <DataTable datasets={datasets} />
       </Primary>
     </Layout>
@@ -37,7 +37,11 @@ const Page = () => (
 export default Page;
 
 const Usage = styled.div`
-  padding-top: 2rem;
+  padding-bottom: 4rem;
+
+  @media (min-width: ${props => props.theme.medium}) {
+    padding-bottom: 0;
+  }
 
   p {
     margin: 0;

--- a/pages/data.js
+++ b/pages/data.js
@@ -5,10 +5,15 @@ import Primary from '../components/Primary';
 import Hero from '../components/Hero';
 import DataTable from '../components/DataTable';
 import content from '../content/interactive.md';
+import Parser from '../components/Parser';
 
 const {
-  attributes: { title, description, datasets },
+  attributes: { title, description, usage, datasets },
 } = content;
+
+const md = require('markdown-it')({
+  html: true,
+});
 
 const Page = () => (
   <React.Fragment>
@@ -18,6 +23,7 @@ const Page = () => (
     <Layout fullWidth flexColumn>
       <Hero title={title} description={description} />
       <Primary>
+        <Parser>{md.render(usage)}</Parser>
         <DataTable datasets={datasets} />
       </Primary>
     </Layout>

--- a/pages/data.js
+++ b/pages/data.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import Head from 'next/head';
+import styled from 'styled-components';
 import Layout from '../components/Layout';
 import Primary from '../components/Primary';
 import Hero from '../components/Hero';
 import DataTable from '../components/DataTable';
 import content from '../content/interactive.md';
-import styled from 'styled-components';
 import Parser from '../components/Parser';
 
 const {

--- a/public/static/admin/config.yml
+++ b/public/static/admin/config.yml
@@ -49,6 +49,7 @@ collections:
       fields:
         - {label: "Title", name: "title", widget: "string"}
         - {label: "Description", name: "description", widget: "text"}
+        - {label: "Terms of Use", name: "usage", widget: "markdown"}
         - label: "Datasets"
           name: "datasets"
           widget: "list"


### PR DESCRIPTION
## What does this do?

- Adds a new "Usage" field to the Netlify CMS allowing content creators to add terms of usage content to the interactive data page.
- Adds base content for new usage area.
- Updates layout on interactive data page to ensure table and main content area doesn't expand past desired max width.

Closes #629 

![image](https://user-images.githubusercontent.com/22242017/122688638-0bc25a80-d1e3-11eb-807f-de913a70a649.png)
