### PR TITLE
Don't run CI on CMS PRs

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,7 +4,8 @@ on: [push, pull_request]
 
 jobs:
   build:
-
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}
+    
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/netlify_cms_config_validation.yml
+++ b/.github/workflows/netlify_cms_config_validation.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 jobs:
   build:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}
+
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
@EvaRuthM noticed that checks were failing on PRs created by updates via Netlify CMS. Here's [an example](https://github.com/texas-justice-initiative/website-nextjs/actions/runs/965802127). The errors are coming from the `actions/checkout` action, and they look like this:

```
Error: fatal: couldn't find remote ref refs/pull/643/merge
```

Checks pass on our other PRs, so my hypothesis is that PRs created in the CMS are merged before the checks have a chance to run, which raises that error.

This PR attempts to stop the failing checks by not running CI on PRs created by the CMS.