### PR TITLE
Fix conditional workflow running

### DIFF
--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,6 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - run: echo "${{ github.event.pull_request.labels.*.name }}"
+    - run: echo "${{ contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}"
+    - run: echo "${{ !contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}"
     - uses: actions/checkout@v1
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - run: echo "${{ github.event.pull_request.labels.*.name }}"
-    - run: echo "${{ contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}"
-    - run: echo "${{ !contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}"
+    - run: echo "${{ github.event.pull_request.branch }}"
+    - run: echo "${{ startsWith(github.event.pull_request.branch, 'workflow-') }}"
+    - run: echo "${{ !startsWith(github.event.pull_request.branch, 'workflow-') }}"
     - uses: actions/checkout@v1
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -4,14 +4,11 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}
+    if: ${{ !startsWith(github.head_ref, 'cms/') }}
     
     runs-on: ubuntu-latest
 
     steps:
-    - run: echo "${{ github.head_ref }}"
-    - run: echo "${{ startsWith(github.head_ref, 'workflow-') }}"
-    - run: echo "${{ !startsWith(github.head_ref, 'workflow-') }}"
     - uses: actions/checkout@v1
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - run: echo "${{ github.event.pull_request.branch }}"
-    - run: echo "${{ startsWith(github.event.pull_request.branch, 'workflow-') }}"
-    - run: echo "${{ !startsWith(github.event.pull_request.branch, 'workflow-') }}"
+    - run: echo "${{ github.head_ref }}"
+    - run: echo "${{ startsWith(github.head_ref, 'workflow-') }}"
+    - run: echo "${{ !startsWith(github.head_ref, 'workflow-') }}"
     - uses: actions/checkout@v1
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1

--- a/.github/workflows/netlify_cms_config_validation.yml
+++ b/.github/workflows/netlify_cms_config_validation.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'netlify-cms/draft') }}
+    if: ${{ !startsWith(github.head_ref, 'cms/') }}
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
This is a second attempt at not running our GitHub Actions workflows on PRs from Netlify CMS. See https://github.com/texas-justice-initiative/website-nextjs/pull/644 for more context. I believe my first attempt didn't work because labels were being set after the PR was initially created.

This PR prevents our workflows from running on PRs whose branch names start with `cms/`, which is the branch naming format that Netlify CMS uses.