### PR TITLE
Improve Header on medium size devices

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -234,6 +234,12 @@ const StyledHeader = styled.header`
 
     @media (min-width: ${props => props.theme.breakpoints.medium}) {
       img {
+        width: 100px;
+      }
+    }
+
+    @media (min-width: ${props => props.theme.breakpoints.large}) {
+      img {
         width: 150px;
       }
     }
@@ -241,7 +247,7 @@ const StyledHeader = styled.header`
 
   /* Mobile Menu */
 
-  @media (max-width: ${props => props.theme.breakpoints.medium}) {
+  @media (max-width: ${props => props.theme.breakpoints.smallMax}) {
     height: ${props => props.theme.mediumHeaderHeight};
 
     nav.main-menu-wrapper {
@@ -324,7 +330,7 @@ const StyledHeader = styled.header`
       position: relative;
 
       li {
-        padding-bottom: 1em;
+        padding-bottom: 0;
 
         @media (min-width: ${props => props.theme.breakpoints.medium}) {
           display: inline-block;
@@ -382,6 +388,7 @@ const StyledHeader = styled.header`
     color: ${props => props.theme.colors.primaryBlue};
     text-decoration: none;
     text-transform: uppercase;
+    font-size: 1.35rem;
     font-weight: 400;
     letter-spacing: 1px;
     margin: 0 1rem;
@@ -399,13 +406,11 @@ const StyledHeader = styled.header`
     background: transparent;
     border: none;
     padding: 0;
-    font-size: 1.6rem;
     cursor: pointer;
   }
 
   .btn--donate {
     margin: 0;
-    margin-bottom: 2rem;
     color: ${props => props.theme.colors.white};
 
     &:hover {

--- a/styles/variables/breakpoints.js
+++ b/styles/variables/breakpoints.js
@@ -4,6 +4,7 @@
 
 export default {
   small: '414px',
+  smallMax: '767px',
   medium: '768px',
   large: '1028px',
 };


### PR DESCRIPTION
## Description
Medium size screens currently cause the header navigation to run out of space and the donate button wraps unelegantly onto the next line. This PR addresses this by reducing the logo size and nav link size slightly for medium size devices. Additionally, it fixes a small bug for devices exactly 768px wide where no menu would show.

## Issue
- #624 

## Screencast
https://user-images.githubusercontent.com/22242017/148261631-34932feb-9b0e-4c0a-9ca0-ccf54ead96f7.mp4


